### PR TITLE
User experience tweaks to Header touchable areas

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -9,6 +9,8 @@ import { FlatButton } from './FlatButton';
 import { GradientView } from './GradientView';
 import { Image } from './Image';
 
+const HEADER_HEIGHT = 38;
+
 interface Props extends Partial<NavigationScreenProps> {
   title: string;
   isBackArrow?: boolean;
@@ -53,10 +55,11 @@ export const Header = ({ title, isBackArrow, isCancelButton, navigation, addFunc
 
 const styles = StyleSheet.create({
   container: {
-    paddingTop: getStatusBarHeight() + 11,
-    paddingBottom: 11,
+    paddingTop: getStatusBarHeight(),
+    height: HEADER_HEIGHT + getStatusBarHeight(),
     flexDirection: 'row',
     justifyContent: 'center',
+    alignItems: 'center',
     width: '100%',
   },
   title: {
@@ -65,8 +68,12 @@ const styles = StyleSheet.create({
   },
   backArrowContainer: {
     position: 'absolute',
-    bottom: 14,
-    left: 28,
+    height: HEADER_HEIGHT,
+    width: HEADER_HEIGHT,
+    justifyContent: 'center',
+    alignItems: 'center',
+    top: getStatusBarHeight(),
+    left: 10,
   },
   cancelButtonContainer: {
     position: 'absolute',
@@ -83,8 +90,11 @@ const styles = StyleSheet.create({
   },
   rightElement: {
     position: 'absolute',
-    padding: 8,
-    right: 11,
-    top: getStatusBarHeight() + 9,
+    height: HEADER_HEIGHT,
+    width: HEADER_HEIGHT,
+    justifyContent: 'center',
+    alignItems: 'center',
+    right: 10,
+    top: getStatusBarHeight(),
   },
 });

--- a/src/screens/CreateWalletScreen.tsx
+++ b/src/screens/CreateWalletScreen.tsx
@@ -162,14 +162,15 @@ export default CreateWalletScreen;
 
 const styles = StyleSheet.create({
   subtitle: {
-    marginTop: 36,
-    marginBottom: 16,
+    marginTop: 12,
+    marginBottom: 18,
     ...typography.headline4,
     textAlign: 'center',
   },
   description: {
-    marginBottom: 40,
+    marginBottom: 52,
     color: palette.textGrey,
+    ...typography.caption,
     textAlign: 'center',
   },
   advancedOptionsLabel: {

--- a/src/screens/WalletDetailsScreen.tsx
+++ b/src/screens/WalletDetailsScreen.tsx
@@ -68,7 +68,7 @@ export default WalletDetailsScreen;
 
 const styles = StyleSheet.create({
   showWalletXPUBContainer: {
-    marginTop: 16,
+    marginTop: 20,
   },
   deleteWalletButtonContainer: {
     marginTop: 12,
@@ -84,7 +84,7 @@ const styles = StyleSheet.create({
     marginTop: 32,
   },
   typeContainer: {
-    marginTop: 16,
+    marginTop: 4,
   },
   typeLabel: {
     color: palette.textGrey,


### PR DESCRIPTION
Header height is now 38 + statusbar height (20 for Android), which translates to 58 - same like on Matt's designs.

Touchable areas are 38x38. It's still smaller than Apple official recommendation of 44 pixels high, but we're close ;) 

<img width="326" alt="Screenshot 2020-04-17 at 10 10 07" src="https://user-images.githubusercontent.com/16637542/79547328-0673f800-8094-11ea-8f28-75b9a3be3073.png">

<img width="287" alt="Screenshot 2020-04-17 at 10 09 45" src="https://user-images.githubusercontent.com/16637542/79547324-0542cb00-8094-11ea-9d5f-04057c032418.png">
