### PR TITLE
Create wallet success screen with mnemonic passphrase

### DIFF
--- a/loc/en.js
+++ b/loc/en.js
@@ -42,6 +42,13 @@ module.exports = {
       multipleAddresses: 'Multiple addresses',
       singleAddress: 'Single address',
     },
+    addSuccess: {
+      title: 'Add new wallet',
+      subtitle: 'Success',
+      description:
+        'Your wallet has been created. Please take a moment to write down this mnemonic phrase on a piece of paper. It’s your backup. You can use it to restore the wallet on other devices.',
+      okButton: 'OK, I wrote this down!',
+    },
     details: {
       latestTransaction: 'Latest transaction',
       typeLabel: 'Type',

--- a/src/components/Chip.tsx
+++ b/src/components/Chip.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+
+import { palette, typography } from 'app/styles';
+
+import { Text } from './Text';
+
+interface Props {
+  label: string;
+}
+
+export class Chip extends React.PureComponent<Props> {
+  render() {
+    return (
+      <View style={styles.container}>
+        <Text style={styles.label}>{this.props.label}</Text>
+      </View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    height: 32,
+    paddingHorizontal: 8,
+    backgroundColor: palette.backgroundDarker,
+    borderRadius: 4,
+    marginEnd: 16,
+    marginBottom: 16,
+  },
+  label: {
+    ...typography.headline5,
+    lineHeight: 32,
+  },
+});

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -18,3 +18,4 @@ export { Text } from './Text';
 export { RadioGroup, RadioButton } from './RadioButtons';
 export { WalletCard } from './WalletCard';
 export { GenericInputItem } from './GenericInputItem';
+export { Chip } from './Chip';

--- a/src/screens/CreateWalletScreen.tsx
+++ b/src/screens/CreateWalletScreen.tsx
@@ -9,25 +9,31 @@ import { AppStorage, HDSegwitBech32Wallet, HDSegwitP2SHWallet, SegwitP2SHWallet,
 import i18n from 'app/locale';
 import { palette, typography } from 'app/styles';
 
+import CreateWalletSuccessScreen from './CreateWalletSuccessScreen';
+
 type Props = NavigationInjectedProps;
 
 interface State {
   label: string;
   isLoading: boolean;
+  isSuccess: boolean;
   activeBitcoin: boolean;
   isAdvancedOptionsEnabled: boolean;
   walletBaseURI: string;
   selectedIndex: number;
+  secret: string[];
 }
 
 export class CreateWalletScreen extends React.PureComponent<Props, State> {
   state: State = {
     label: '',
     isLoading: false,
+    isSuccess: false,
     activeBitcoin: false,
     isAdvancedOptionsEnabled: false,
     walletBaseURI: '',
     selectedIndex: 0,
+    secret: [],
   };
 
   static navigationOptions = (props: NavigationScreenProps) => ({
@@ -81,13 +87,9 @@ export class CreateWalletScreen extends React.PureComponent<Props, State> {
       BlueApp.wallets.push(wallet);
       await BlueApp.saveToDisk();
       EV(EV.enum.WALLETS_COUNT_CHANGED);
-      this.props.navigation.goBack();
-      // if (wallet.type === HDSegwitP2SHWallet.type || wallet.type === HDSegwitBech32Wallet.type) {
-      //   this.props.navigation.navigate('PleaseBackup', {
-      //     secret: wallet.getSecret(),
-      //   });
-      // }
+      this.setState({ isSuccess: true, secret: wallet.getSecret().split(' ') });
     }
+    this.setState({ isLoading: false });
   };
 
   get canCreateWallet(): boolean {
@@ -132,6 +134,9 @@ export class CreateWalletScreen extends React.PureComponent<Props, State> {
   }
 
   render() {
+    if (this.state.isSuccess) {
+      return <CreateWalletSuccessScreen secret={this.state.secret} navigation={this.props.navigation} />;
+    }
     return (
       <ScreenTemplate
         footer={

--- a/src/screens/CreateWalletSuccessScreen.tsx
+++ b/src/screens/CreateWalletSuccessScreen.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+import { NavigationInjectedProps, NavigationScreenProps } from 'react-navigation';
+
+import { Button, Header, ScreenTemplate, Text, Chip } from 'app/components';
+import i18n from 'app/locale';
+import { palette, typography } from 'app/styles';
+
+interface Props extends NavigationInjectedProps {
+  secret: string[];
+}
+
+export class CreateWalletSuccessScreen extends React.PureComponent<Props> {
+  static navigationOptions = (props: NavigationScreenProps) => ({
+    header: <Header navigation={props.navigation} title={i18n.wallets.add.title} />,
+  });
+
+  navigateBack = () => this.props.navigation.goBack();
+
+  render() {
+    return (
+      <ScreenTemplate
+        footer={
+          <>
+            <Button onPress={this.navigateBack} title={i18n.wallets.addSuccess.okButton} />
+          </>
+        }>
+        <Text style={styles.subtitle}>{i18n.wallets.addSuccess.subtitle}</Text>
+        <Text style={styles.description}>{i18n.wallets.addSuccess.description}</Text>
+        <View style={styles.mnemonicPhraseContainer}>
+          {this.props.secret.map((secret, index) => (
+            <Chip key={index.toString()} label={`${index + 1}. ${secret}`} />
+          ))}
+        </View>
+      </ScreenTemplate>
+    );
+  }
+}
+
+export default CreateWalletSuccessScreen;
+
+const styles = StyleSheet.create({
+  subtitle: {
+    marginTop: 12,
+    marginBottom: 18,
+    ...typography.headline4,
+    textAlign: 'center',
+  },
+  description: {
+    marginBottom: 52,
+    color: palette.textGrey,
+    ...typography.caption,
+    textAlign: 'center',
+  },
+  mnemonicPhraseContainer: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'center',
+    paddingHorizontal: 12,
+  },
+});

--- a/src/styles/palette.tsx
+++ b/src/styles/palette.tsx
@@ -12,6 +12,7 @@ export const palette = {
   gradientSecondaryFirst: 'rgb(255, 214, 99)',
   gradientSecondarySecond: 'rgb(200, 156, 101)',
   background: '#fff',
+  backgroundDarker: 'rgb(234, 234, 234)',
   border: 'rgb(204, 204, 204)',
   error: 'rgb(244, 94, 89)',
   shadow: 'rgba(0, 0, 0, 0.12)',


### PR DESCRIPTION
An easter egg: take a look how it was done previously. Every chip was a separate component, without a map.

```
 <View style={{ width: 'auto', marginRight: 8, marginBottom: 8 }}>
                <Badge
                  containerStyle={{
                    backgroundColor: '#f5f5f5',
                    paddingTop: 6,
                    paddingBottom: 6,
                    paddingLeft: 8,
                    paddingRight: 8,
                    borderRadius: 4,
                  }}>
                  <Text style={{ color: '#81868E', fontWeight: 'bold' }}>1. {this.state.words[0]}</Text>
                </Badge>
              </View>
```
And copy paste it 24 times :D 

![Simulator Screen Shot - iPhone 11 - 2020-04-17 at 11 03 34](https://user-images.githubusercontent.com/16637542/79553097-44751a00-809c-11ea-9af9-d292370217d8.png)
