### PR TITLE
UI adjustments

### DIFF
--- a/class/hd-segwit-bech32-wallet.js
+++ b/class/hd-segwit-bech32-wallet.js
@@ -21,7 +21,7 @@ const { RNRandomBytes } = NativeModules;
  */
 export class HDSegwitBech32Wallet extends AbstractHDWallet {
   static type = 'HDsegwitBech32';
-  static typeReadable = 'HD SegWit (BIP84 Bech32 Native)';
+  static typeReadable = 'HD SegWit';
   static defaultRBFSequence = 2147483648; // 1 << 31, minimum for replaceable transactions as per BIP68
 
   constructor() {

--- a/class/hd-segwit-p2sh-wallet.js
+++ b/class/hd-segwit-p2sh-wallet.js
@@ -48,7 +48,7 @@ function nodeToP2shSegwitAddress(hdNode) {
  */
 export class HDSegwitP2SHWallet extends AbstractHDWallet {
   static type = 'HDsegwitP2SH';
-  static typeReadable = 'HD SegWit (BIP49 P2SH)';
+  static typeReadable = 'HD P2SH';
 
   allowSend() {
     return true;

--- a/class/segwit-p2sh-wallet.js
+++ b/class/segwit-p2sh-wallet.js
@@ -22,7 +22,7 @@ function pubkeyToP2shSegwitAddress(pubkey, network) {
 
 export class SegwitP2SHWallet extends LegacyWallet {
   static type = 'segwitP2SH';
-  static typeReadable = 'SegWit (P2SH)';
+  static typeReadable = 'P2SH';
 
   allowRBF() {
     return true;

--- a/loc/en.js
+++ b/loc/en.js
@@ -46,6 +46,11 @@ module.exports = {
     confirmButton: 'Confirm fingerprint to continue.',
     enter: 'Enter PIN',
   },
+  unlockTransaction: {
+    headerText: 'Confirm transaction',
+    title: 'Confirm Transaction Password',
+    description: 'Confirm Transaction Password in order to proceed the transaction.',
+  },
   wallets: {
     dashboard: {
       title: 'Wallets',
@@ -98,8 +103,9 @@ module.exports = {
       addWalletButton: 'Add new wallet',
       importWalletButton: 'Import wallet',
       advancedOptions: 'Advanced options',
-      multipleAddresses: 'Multiple addresses',
-      singleAddress: 'Single address',
+      multipleAddresses: 'It contains a tree of P2SH addresses generated from a single 24-word seed',
+      singleAddress: 'It contains a single P2SH address',
+      segwidAddress: 'It contains a tree of native segwit addresses, generated from a single 24-word seed',
     },
     addSuccess: {
       title: 'Add new wallet',
@@ -254,6 +260,9 @@ module.exports = {
   },
   electrumServer: {
     header: 'Electrum server',
+    title: 'Change electrum server',
+    description:
+      'You can change the address of the server your application will connect to. Default address is recommended.',
     save: 'Save',
     useDefault: 'Use default',
     host: 'host',
@@ -264,7 +273,7 @@ module.exports = {
   advancedOptions: {
     title: 'Configure advanced options',
     description:
-      'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
+      'Enabling Advanced options will allow you to choose from wallet types listed below: \nP2SH, HD P2SH, HD segwit.',
   },
   selectLanguage: {
     header: 'Language',

--- a/src/consts/models.tsx
+++ b/src/consts/models.tsx
@@ -45,6 +45,7 @@ export enum Route {
   CreateTransactionPassword = 'CreateTransactionPassword',
   ConfirmTransactionPassword = 'ConfirmTransactionPassword',
   AdvancedOptions = 'AdvancedOptions',
+  UnlockTransaction = 'UnlockTransaction',
 }
 
 export interface Wallet {

--- a/src/navigators/RootNavigator.tsx
+++ b/src/navigators/RootNavigator.tsx
@@ -2,20 +2,21 @@ import { Easing, Animated } from 'react-native';
 import { createStackNavigator, NavigationSceneRendererProps } from 'react-navigation';
 
 import { Route } from 'app/consts';
-import { ActionSheet, ImportWalletQRCodeScreen, UnlockScreen } from 'app/screens';
+import { ActionSheet, ImportWalletQRCodeScreen } from 'app/screens';
 
 import { EditTextNavigator } from './EditTextNavigator';
 import { MainCardStackNavigator } from './MainCardStackNavigator';
 import { MessageNavigator } from './MessageNavigator';
 import { PasswordNavigator } from './PasswordNavigator';
 import { PinNavigator } from './PinNavigator';
+import { UnlockTransactionNavaigator } from './UnlockTransactionNavaigator';
 
 export const RootNavigator = createStackNavigator(
   {
     MainCardStackNavigator,
     [Route.ImportWalletQRCode]: ImportWalletQRCodeScreen,
     [Route.ActionSheet]: ActionSheet,
-    [Route.UnlockScreen]: UnlockScreen,
+    UnlockTransactionNavaigator,
     PinNavigator,
     PasswordNavigator,
     EditTextNavigator,

--- a/src/navigators/UnlockTransactionNavaigator.tsx
+++ b/src/navigators/UnlockTransactionNavaigator.tsx
@@ -1,0 +1,13 @@
+import { createStackNavigator } from 'react-navigation';
+
+import { Route } from 'app/consts';
+import { UnlockTransaction } from 'app/screens';
+
+export const UnlockTransactionNavaigator = createStackNavigator(
+  {
+    [Route.UnlockTransaction]: UnlockTransaction,
+  },
+  {
+    headerMode: 'screen',
+  },
+);

--- a/src/navigators/index.tsx
+++ b/src/navigators/index.tsx
@@ -1,2 +1,3 @@
 export { MainTabNavigator } from './MainTabNavigator';
 export { RootNavigator } from './RootNavigator';
+export { UnlockTransactionNavaigator } from './UnlockTransactionNavaigator';

--- a/src/screens/CreateWalletScreen.tsx
+++ b/src/screens/CreateWalletScreen.tsx
@@ -115,22 +115,22 @@ export class CreateWalletScreen extends React.PureComponent<Props, State> {
         <>
           <Text style={styles.advancedOptionsLabel}>{i18n.wallets.add.advancedOptions}</Text>
           <RadioGroup color={palette.secondary} onSelect={this.onSelect} selectedIndex={this.state.selectedIndex}>
-            <RadioButton style={styles.radioButton} value={HDSegwitP2SHWallet.type}>
-              <View style={styles.radioButtonContent}>
-                <Text style={styles.radioButtonTitle}>{HDSegwitP2SHWallet.typeReadable}</Text>
-                <Text style={styles.radioButtonSubtitle}>{i18n.wallets.add.multipleAddresses}</Text>
-              </View>
-            </RadioButton>
             <RadioButton style={styles.radioButton} value={SegwitP2SHWallet.type}>
               <View style={styles.radioButtonContent}>
                 <Text style={styles.radioButtonTitle}>{SegwitP2SHWallet.typeReadable}</Text>
                 <Text style={styles.radioButtonSubtitle}>{i18n.wallets.add.singleAddress}</Text>
               </View>
             </RadioButton>
+            <RadioButton style={styles.radioButton} value={HDSegwitP2SHWallet.type}>
+              <View style={styles.radioButtonContent}>
+                <Text style={styles.radioButtonTitle}>{HDSegwitP2SHWallet.typeReadable}</Text>
+                <Text style={styles.radioButtonSubtitle}>{i18n.wallets.add.multipleAddresses}</Text>
+              </View>
+            </RadioButton>
             <RadioButton style={styles.radioButton} value={HDSegwitBech32Wallet.type}>
               <View style={styles.radioButtonContent}>
                 <Text style={styles.radioButtonTitle}>{HDSegwitBech32Wallet.typeReadable}</Text>
-                <Text style={styles.radioButtonSubtitle}>{i18n.wallets.add.multipleAddresses}</Text>
+                <Text style={styles.radioButtonSubtitle}>{i18n.wallets.add.segwidAddress}</Text>
               </View>
             </RadioButton>
           </RadioGroup>

--- a/src/screens/SendCoinsConfirmScreen.tsx
+++ b/src/screens/SendCoinsConfirmScreen.tsx
@@ -121,8 +121,7 @@ export class SendCoinsConfirmScreen extends Component<Props> {
   };
 
   goToUnlockScreen = () => {
-    this.props.navigation.navigate(Route.UnlockScreen, {
-      flowType: FlowType.password,
+    this.props.navigation.navigate(Route.UnlockTransaction, {
       onSuccess: this.broadcast,
     });
   };

--- a/src/screens/Settings/ElectrumServerScreen.tsx
+++ b/src/screens/Settings/ElectrumServerScreen.tsx
@@ -1,10 +1,11 @@
 import AsyncStorage from '@react-native-community/async-storage';
 import React, { useEffect, useState } from 'react';
-import { StyleSheet } from 'react-native';
+import { StyleSheet, Alert, Text } from 'react-native';
 import { NavigationScreenProps } from 'react-navigation';
 
 import { ScreenTemplate, Button, FlatButton, InputItem, Header } from 'app/components';
 import { AppStorage, defaultPeer } from 'app/legacy';
+import { typography, palette } from 'app/styles';
 
 const BlueElectrum = require('../../../BlueElectrum');
 const i18n = require('../../../loc');
@@ -32,14 +33,14 @@ export const ElectrumServerScreen = () => {
     (async () => {
       try {
         if (!(await BlueElectrum.testConnection(host, port))) {
-          alert(i18n.electrumServer.connectionError);
+          Alert.alert(i18n.electrumServer.connectionError);
         } else {
           await AsyncStorage.setItem(AppStorage.ELECTRUM_HOST, host);
           await AsyncStorage.setItem(AppStorage.ELECTRUM_TCP_PORT, port);
-          alert(i18n.electrumServer.successfullSave);
+          Alert.alert(i18n.electrumServer.successfullSave);
         }
       } catch (error) {
-        alert(i18n.electrumServer.connectionError);
+        Alert.alert(i18n.electrumServer.connectionError);
       }
 
       setIsLoading(false);
@@ -59,6 +60,8 @@ export const ElectrumServerScreen = () => {
         </>
       }
     >
+      <Text style={styles.title}>{i18n.electrumServer.title}</Text>
+      <Text style={styles.description}>{i18n.electrumServer.description}</Text>
       <InputItem
         setValue={setHost}
         label={i18n.electrumServer.host}
@@ -83,4 +86,18 @@ ElectrumServerScreen.navigationOptions = (props: NavigationScreenProps) => ({
 
 const styles = StyleSheet.create({
   saveButton: { paddingBottom: 10 },
+  title: {
+    ...typography.headline4,
+    alignSelf: 'center',
+    marginTop: 10,
+  },
+  description: {
+    ...typography.caption,
+    color: palette.textGrey,
+    alignSelf: 'center',
+    marginTop: 20,
+    marginBottom: 40,
+    marginHorizontal: 15,
+    textAlign: 'center',
+  },
 });

--- a/src/screens/UnlockScreen.tsx
+++ b/src/screens/UnlockScreen.tsx
@@ -1,22 +1,19 @@
 import React, { PureComponent } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 import { NavigationScreenProps, NavigationInjectedProps } from 'react-navigation';
-import { connect } from 'react-redux';
 
 import { images } from 'app/assets';
-import { Header, PinInput, Image, InputItem, ScreenTemplate, Button } from 'app/components';
-import { CONST, FlowType } from 'app/consts';
+import { Header, PinInput, Image, ScreenTemplate } from 'app/components';
+import { CONST } from 'app/consts';
 import { BiometricService, SecureStorageService } from 'app/services';
-import { ApplicationState } from 'app/state';
 import { palette, typography } from 'app/styles';
 
 const BlueApp = require('../../BlueApp');
 const i18n = require('../../loc');
 
-interface Props extends NavigationInjectedProps<{ onSuccess: () => void; flowType: string }> {
+interface Props {
   onSuccessfullyAuthenticated?: () => void;
   isBiometricEnabledByUser: boolean;
-  appSettings?: any;
 }
 
 interface State {
@@ -25,16 +22,11 @@ interface State {
   showInput: boolean;
 }
 
-class UnlockScreen extends PureComponent<Props, State> {
+export class UnlockScreen extends PureComponent<Props, State> {
   static navigationOptions = (props: NavigationScreenProps) => ({
-    header: (
-      <Header
-        navigation={props.navigation}
-        title={i18n.unlock.title}
-        isBackArrow={props.navigation && props.navigation.getParam('flowType') === FlowType.password}
-      />
-    ),
+    header: <Header navigation={props.navigation} title={i18n.unlock.title} />,
   });
+
   state = {
     pin: '',
     error: '',
@@ -45,10 +37,7 @@ class UnlockScreen extends PureComponent<Props, State> {
 
   async componentDidMount() {
     await BlueApp.startAndDecrypt();
-    if (this.props.navigation && this.props.navigation.getParam('flowType') === FlowType.password) {
-      return this.openKeyboard();
-    }
-    if (this.props.isBiometricEnabledByUser || this.props.appSettings.isBiometricsEnabled) {
+    if (this.props.isBiometricEnabledByUser) {
       await this.unlockWithBiometrics();
     }
   }
@@ -73,20 +62,6 @@ class UnlockScreen extends PureComponent<Props, State> {
     }
   };
 
-  onSave = async () => {
-    const onSuccessFn = this.props.navigation.getParam('onSuccess');
-    if (await SecureStorageService.checkSecuredPassword('transactionPassword', this.state.pin)) {
-      onSuccessFn();
-    } else {
-      this.setState({
-        pin: '',
-        error: i18n.onboarding.passwordDoesNotMatch,
-      });
-    }
-  };
-
-  updatePassword = (password: string) => this.setState({ pin: password });
-
   updatePin = (pin: string) => {
     this.setState({ pin }, async () => {
       if (this.state.pin.length === CONST.pinCodeLength) {
@@ -95,7 +70,7 @@ class UnlockScreen extends PureComponent<Props, State> {
           this.props.onSuccessfullyAuthenticated && this.props.onSuccessfullyAuthenticated();
         } else {
           this.setState({
-            error: i18n.onboarding.passwordDoesNotMatch,
+            error: i18n.onboarding.pinDoesNotMatch,
             pin: '',
           });
         }
@@ -104,59 +79,34 @@ class UnlockScreen extends PureComponent<Props, State> {
   };
 
   openKeyboard = () => {
-    if (
-      this.inputRef.current &&
-      this.props.navigation &&
-      this.props.navigation.getParam('flowType') === FlowType.password
-    ) {
+    if (this.inputRef.current) {
       this.inputRef.current.inputItemRef.current.focus();
     }
   };
 
   render() {
-    const { error, pin, showInput } = this.state;
-    const isPassword = this.props.navigation && !!this.props.navigation.getParam('flowType');
+    const { error, pin } = this.state;
     return (
       <ScreenTemplate
         contentContainer={styles.container}
         footer={
-          isPassword ? (
-            <Button title="Save" onPress={this.onSave} disabled={pin.length < CONST.transactionMinPasswordLength} />
-          ) : (
-            showInput && (
-              <View style={styles.pinContainer}>
-                <PinInput value={pin} onTextChange={pin => this.updatePin(pin)} />
-                <Text style={styles.errorText}>{error}</Text>
-              </View>
-            )
-          )
+          <View style={styles.pinContainer}>
+            <PinInput value={pin} onTextChange={pin => this.updatePin(pin)} />
+            <Text style={styles.errorText}>{error}</Text>
+          </View>
         }
       >
         <Image source={images.portraitLogo} style={styles.logo} resizeMode="contain" />
-        {isPassword && (
-          <View style={styles.inputItemContainer}>
-            <InputItem label="password" value={pin} setValue={this.updatePassword} ref={this.inputRef} error={error} />
-          </View>
-        )}
       </ScreenTemplate>
     );
   }
 }
-
-const mapStateToProps = (state: ApplicationState) => ({
-  appSettings: state.appSettings,
-});
-
-export default connect(mapStateToProps)(UnlockScreen);
 
 const styles = StyleSheet.create({
   container: {
     backgroundColor: palette.white,
     alignItems: 'center',
     justifyContent: 'center',
-  },
-  inputItemContainer: {
-    width: '100%',
   },
   pinContainer: {
     alignItems: 'center',

--- a/src/screens/UnlockTransaction.tsx
+++ b/src/screens/UnlockTransaction.tsx
@@ -1,0 +1,117 @@
+import React, { PureComponent } from 'react';
+import { StyleSheet, Text, View, TouchableOpacity, Image } from 'react-native';
+import { NavigationScreenProps, NavigationInjectedProps } from 'react-navigation';
+
+import { icons } from 'app/assets';
+import { Header, InputItem, ScreenTemplate, Button } from 'app/components';
+import { CONST } from 'app/consts';
+import { SecureStorageService } from 'app/services';
+import { palette, typography } from 'app/styles';
+
+const i18n = require('../../loc');
+
+type Props = NavigationInjectedProps<{ onSuccess: () => void }>;
+
+interface State {
+  password: string;
+  error: string;
+  isVisible: boolean;
+}
+
+export class UnlockTransaction extends PureComponent<Props, State> {
+  static navigationOptions = (props: NavigationScreenProps) => ({
+    header: <Header navigation={props.navigation} title={i18n.unlockTransaction.headerText} isBackArrow />,
+  });
+
+  state = {
+    password: '',
+    error: '',
+    isVisible: false,
+  };
+
+  inputRef: any = React.createRef();
+
+  onConfirm = async () => {
+    const onSuccessFn = this.props.navigation.getParam('onSuccess');
+    if (await SecureStorageService.checkSecuredPassword('transactionPassword', this.state.password)) {
+      onSuccessFn();
+    } else {
+      this.setState({
+        password: '',
+        error: i18n.onboarding.passwordDoesNotMatch,
+      });
+    }
+  };
+
+  changeVisability = () => {
+    this.setState({
+      isVisible: !this.state.isVisible,
+    });
+  };
+
+  updatePassword = (password: string) => this.setState({ password });
+
+  render() {
+    const { error, password, isVisible } = this.state;
+    return (
+      <ScreenTemplate
+        contentContainer={styles.container}
+        footer={
+          <Button
+            title="Confirm"
+            onPress={this.onConfirm}
+            disabled={password.length < CONST.transactionMinPasswordLength}
+          />
+        }
+      >
+        <Text style={styles.title}>{i18n.unlockTransaction.title}</Text>
+        <Text style={styles.description}>{i18n.unlockTransaction.description}</Text>
+        <View style={styles.inputContainer}>
+          <TouchableOpacity style={styles.visibilityIcon} onPress={this.changeVisability}>
+            <Image style={styles.icon} source={!isVisible ? icons.visibilityOn : icons.visibilityOff} />
+          </TouchableOpacity>
+          <InputItem
+            value={password}
+            ref={this.inputRef}
+            setValue={this.updatePassword}
+            autoFocus={true}
+            secureTextEntry={!isVisible}
+            error={error}
+          />
+        </View>
+      </ScreenTemplate>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: palette.white,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  title: {
+    ...typography.headline4,
+    alignSelf: 'center',
+    marginTop: 10,
+  },
+  inputContainer: {
+    width: '100%',
+  },
+  visibilityIcon: { position: 'absolute', right: 0, bottom: 36, zIndex: 3 },
+
+  description: {
+    ...typography.caption,
+    color: palette.textGrey,
+    alignSelf: 'center',
+    marginTop: 20,
+    marginBottom: 40,
+    marginHorizontal: 15,
+    textAlign: 'center',
+  },
+  icon: {
+    width: 24,
+    height: 24,
+    padding: 8,
+  },
+});

--- a/src/screens/index.tsx
+++ b/src/screens/index.tsx
@@ -29,4 +29,5 @@ export { ConfirmPinScreen } from './PinFlow/ConfirmPinScreen';
 export { CurrentPinScreen } from './PinFlow/CurrentPinScreen';
 export { CreateTransactionPassword } from './PinFlow/CreateTransactionPassword';
 export { ConfirmTransactionPassword } from './PinFlow/ConfirmTransactionPassword';
-export { default as UnlockScreen } from './UnlockScreen';
+export { UnlockTransaction } from './UnlockTransaction';
+export { UnlockScreen } from './UnlockScreen';


### PR DESCRIPTION
5b_dashboard_add_wallet_advanced - zmiana nazwy typu wallet'ów oraz ich opis
5c_dashboard_add_wallet_advanced_error - identyczna zmiana, jak wyżej
40_settings_electrum_server - dodanie nagłówka i opisu do sekcji
45b_advanced_options - dodanie nagłówka i opisu do sekcji
81_transaction_confirm - widok potwierdzenia Transaction Password pojawiający się od razu po próbie przeprocesowania transakcji
82_transaction_confirm_filled - widok potwierdzenia Transaction Password z wypełnionymi danymi. Funkcjonalność podejrzenia hasła w tym widoku, jak i w poprzednim działa identycznie, jak na onboarding'u