### PR TITLE
display network info

### DIFF
--- a/src/screens/Settings/SettingsScreen.tsx
+++ b/src/screens/Settings/SettingsScreen.tsx
@@ -1,6 +1,6 @@
 import { StackNavigationProp } from '@react-navigation/stack';
 import React, { useEffect, useState } from 'react';
-import { StyleSheet } from 'react-native';
+import { StyleSheet, Text } from 'react-native';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { icons } from 'app/assets';
@@ -11,6 +11,7 @@ import { BiometricService, AppStateManager } from 'app/services';
 import { ApplicationState } from 'app/state';
 import { updateBiometricSetting } from 'app/state/appSettings/actions';
 
+import config from '../../../config/';
 import { LabeledSettingsRow } from './LabeledSettingsRow';
 
 const i18n = require('../../../loc');
@@ -91,6 +92,7 @@ export const SettingsScreen = (props: Props) => {
       {/*	
        // @ts-ignore */}
       <Header navigation={props.navigation} title={i18n.settings.header} />
+      <Text>{`Network info: ${config.host}:${config.port}`}</Text>
       <ScreenTemplate>
         <Image source={logoSource} style={styles.logo} resizeMode="contain" />
         <LabeledSettingsRow label={i18n.settings.general}>{renderGeneralSettings()}</LabeledSettingsRow>


### PR DESCRIPTION
A small feature to display network info on the settings screen (for testers). Will be removed before the release. Agreed by @jakubkornafel 