### PR TITLE
Fixed failing Authenticators tests

### DIFF
--- a/tests/e2e/pageObjects/common/MessageScreen.ts
+++ b/tests/e2e/pageObjects/common/MessageScreen.ts
@@ -12,7 +12,11 @@ const MessageScreen = (type: MessageScreenType) => ({
     await actions.tap(this.closeButton);
   },
 
-  async waitUntilEnded(): Promise<void> {},
+  async waitUntilEnded(): Promise<void> {
+    await waitFor(this.icon)
+      .toBeNotVisible()
+      .withTimeout(30 * 1000);
+  },
 });
 
 export default MessageScreen;

--- a/tests/e2e/pageObjects/pages/Authenticators.ts
+++ b/tests/e2e/pageObjects/pages/Authenticators.ts
@@ -28,7 +28,7 @@ const Authenticators = () => {
       importButton: element(by.id('import-authenticator')),
 
       async typeName(value: string) {
-        await actions.typeText(this.nameInput, value);
+        await actions.typeText(this.nameInput, value, { closeKeyboard: true });
       },
 
       async submit() {


### PR DESCRIPTION
Tests are failing in Bitrise on the of step closing a success screen after creating authenticators

Changes:
- Added missing implementation of `waitUntilEnded()`
- Make Detox close keyboard after entering authenticator name on Create Authenticator screen
