### PR TITLE
Tests/chamber of secrets

### DIFF
--- a/.detoxrc.json
+++ b/.detoxrc.json
@@ -4,7 +4,7 @@
   "configurations": {
     "ios.sim.prod.debug": {
       "binaryPath": "ios/build/Build/Products/Debug-iphonesimulator/GoldWallet.app",
-      "build": "RN_SRC_EXT=e2e.tsx xcodebuild -workspace ios/GoldWallet.xcworkspace -scheme \"GoldWallet (Debug)\" -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build -quiet",
+      "build": "RN_SRC_EXT=e2e.tsx CHAMBER_OF_SECRETS=true xcodebuild -workspace ios/GoldWallet.xcworkspace -scheme \"GoldWallet (Debug)\" -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build -quiet",
       "type": "ios.simulator",
       "device": {
         "type": "iPhone 11"
@@ -12,14 +12,14 @@
     },
     "ios.sim.prod.staging": {
       "binaryPath": "ios/build/Build/Products/Release-iphonesimulator/GoldWallet.app",
-      "build": "RN_SRC_EXT=e2e.tsx xcodebuild -workspace ios/GoldWallet.xcworkspace -scheme \"GoldWallet (Staging)\" -configuration Release -sdk iphonesimulator -derivedDataPath ios/build -quiet",
+      "build": "RN_SRC_EXT=e2e.tsx CHAMBER_OF_SECRETS=true xcodebuild -workspace ios/GoldWallet.xcworkspace -scheme \"GoldWallet (Staging)\" -configuration Release -sdk iphonesimulator -derivedDataPath ios/build -quiet",
       "type": "ios.simulator",
       "device": {
         "type": "iPhone 11"
       }
     },
     "android.emu.prod.debug": {
-      "build": "cd android && RN_SRC_EXT=e2e.tsx ./gradlew assembleProdDebug assembleProdDebugAndroidTest -DtestBuildType=debug && cd ..",
+      "build": "cd android && RN_SRC_EXT=e2e.tsx CHAMBER_OF_SECRETS=true ./gradlew assembleProdDebug assembleProdDebugAndroidTest -DtestBuildType=debug && cd ..",
       "type": "android.emulator",
       "binaryPath": "android/app/build/outputs/apk/prod/debug/app-prod-debug.apk",
       "device": {

--- a/babel.config.js
+++ b/babel.config.js
@@ -13,7 +13,7 @@ module.exports = {
     [
       'transform-inline-environment-variables',
       {
-        include: ['NODE_ENV', 'LOG_BOX_IGNORE'],
+        include: ['NODE_ENV', 'LOG_BOX_IGNORE', 'CHAMBER_OF_SECRETS'],
       },
     ],
   ],

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "postinstall": "./node_modules/.bin/rn-nodeify --install buffer,events,process,stream,util,inherits,fs,path --hack; npx jetify",
     "clean": "cd android/; ./gradlew clean; cd ..; rm -r -f /tmp/metro-cache/; rm -r -f node_modules/; yarn cache clean --force; yarn install",
     "start": "react-native start",
-    "start:detox": "LOG_BOX_IGNORE=true RN_SRC_EXT=e2e.tsx react-native start --reset-cache",
+    "start:detox": "LOG_BOX_IGNORE=true CHAMBER_OF_SECRETS=true RN_SRC_EXT=e2e.tsx react-native start --reset-cache",
     "debug": "open 'rndebugger://set-debugger-loc?host=localhost&port=8081'",
     "android:prod": "react-native run-android --variant=prodDebug",
     "android:beta": "react-native run-android --variant=betaDebug --appIdSuffix beta",

--- a/src/components/GradientView.tsx
+++ b/src/components/GradientView.tsx
@@ -9,6 +9,7 @@ export enum GradientVariant {
   Primary = 'Primary',
   Secondary = 'Secondary',
 }
+
 interface Props {
   children?: React.ReactNode;
   variant: GradientVariant;

--- a/src/components/RadioButton.tsx
+++ b/src/components/RadioButton.tsx
@@ -7,7 +7,7 @@ import { palette, typography } from 'app/styles';
 
 interface Props<T> {
   title: string;
-  subtitle: string;
+  subtitle?: string;
   value: T;
   checked: boolean;
   onPress?: (value: T) => void;
@@ -31,7 +31,7 @@ export const RadioButton = <T extends unknown>(props: Props<T>) => {
     props.onPress && props.onPress(props.value);
   };
 
-  const renderTitle = (title: string, subtitle: string) => (
+  const renderTitle = (title: string, subtitle?: string) => (
     <View style={styles.radioButtonContent}>
       <Text style={styles.radioButtonTitle}>{title}</Text>
       <Text style={styles.radioButtonSubtitle}>{subtitle}</Text>

--- a/src/navigators/Navigator.tsx
+++ b/src/navigators/Navigator.tsx
@@ -145,9 +145,6 @@ class Navigator extends React.Component<Props, State> {
       return null;
     }
 
-    console.warn('CHAMBER_OF_SECRETS', process.env.CHAMBER_OF_SECRETS);
-    console.warn('isChamberOfSecretsClosed', this.state.isChamberOfSecretsClosed);
-
     if (process.env.CHAMBER_OF_SECRETS === 'true' && !this.state.isChamberOfSecretsClosed) {
       return <ChamberOfSecrets onButtonPress={this.handleOpenChamberOfSecrets} />;
     }

--- a/src/navigators/Navigator.tsx
+++ b/src/navigators/Navigator.tsx
@@ -11,6 +11,7 @@ import { RenderMessage, MessageType } from 'app/helpers/MessageCreator';
 import { RootNavigator, PasswordNavigator } from 'app/navigators';
 import { UnlockScreen, TermsConditionsScreen, ConnectionIssuesScreen } from 'app/screens';
 import { BetaVersionScreen } from 'app/screens/BetaVersionScreen';
+import ChamberOfSecrets from 'app/screens/ChamberOfSecrets';
 import { navigationRef } from 'app/services';
 import { checkDeviceSecurity } from 'app/services/DeviceSecurityService';
 import { ApplicationState } from 'app/state';
@@ -60,12 +61,14 @@ type Props = MapStateToProps & ActionsDisptach & OwnProps;
 interface State {
   isBetaVersionRiskAccepted: boolean;
   isEmulator: boolean;
+  isChamberOfSecretsClosed: boolean;
 }
 
 class Navigator extends React.Component<Props, State> {
   state = {
     isBetaVersionRiskAccepted: false,
     isEmulator: false,
+    isChamberOfSecretsClosed: false,
   };
 
   componentDidMount() {
@@ -131,10 +134,22 @@ class Navigator extends React.Component<Props, State> {
     this.setState({ isBetaVersionRiskAccepted: true });
   };
 
+  handleOpenChamberOfSecrets = () => {
+    this.setState({ isChamberOfSecretsClosed: true });
+  };
+
   renderRoutes = () => {
     const { isLoading, unlockKey, isAuthenticated, hasConnectedToServerAtLeaseOnce, isTcAccepted } = this.props;
+
     if (isLoading) {
       return null;
+    }
+
+    console.warn('CHAMBER_OF_SECRETS', process.env.CHAMBER_OF_SECRETS);
+    console.warn('isChamberOfSecretsClosed', this.state.isChamberOfSecretsClosed);
+
+    if (process.env.CHAMBER_OF_SECRETS === 'true' && !this.state.isChamberOfSecretsClosed) {
+      return <ChamberOfSecrets onButtonPress={this.handleOpenChamberOfSecrets} />;
     }
 
     if (!isTcAccepted) {

--- a/src/screens/ChamberOfSecrets.tsx
+++ b/src/screens/ChamberOfSecrets.tsx
@@ -1,8 +1,6 @@
 /* eslint-disable react-native/no-raw-text */
 /* eslint-disable react-native/no-color-literals */
 /* eslint-disable react/no-unescaped-entities */
-import { CompositeNavigationProp } from '@react-navigation/native';
-import { StackNavigationProp } from '@react-navigation/stack';
 import React, { useState } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { connect } from 'react-redux';
@@ -18,7 +16,7 @@ import {
   Text,
 } from 'app/components';
 import { HEADER_HEIGHT } from 'app/components/Header';
-import { RootStackParams, Route, MainCardStackNavigatorParams, ImportWalletType, Wallet } from 'app/consts';
+import { ImportWalletType, Wallet } from 'app/consts';
 import { HDSegwitP2SHArWallet, HDSegwitP2SHAirWallet } from 'app/legacy';
 import { createPin, createTxPassword, setIsTcAccepted } from 'app/state/authentication/actions';
 import { importWallet } from 'app/state/wallets/actions';
@@ -38,19 +36,15 @@ const chamberOfSecretsGradient = {
 };
 
 interface Props {
-  navigation: CompositeNavigationProp<
-    StackNavigationProp<RootStackParams, Route.MainCardStackNavigator>,
-    StackNavigationProp<MainCardStackNavigatorParams, Route.ConfirmPin>
-  >;
-  createPin: (value: string, { onSuccess }: { onSuccess: () => void }) => void;
-  createTxPassword: (value: string, { onSuccess }: { onSuccess: () => void }) => void;
+  createPin: (value: string, { onSuccess }?: { onSuccess?: () => void }) => void;
+  createTxPassword: (value: string, { onSuccess }?: { onSuccess?: () => void }) => void;
   setIsTcAccepted: (value: boolean) => void;
-  importWallet: (wallet: Wallet, { onSuccess }: { onSuccess: () => void }) => void;
+  importWallet: (wallet: Wallet, { onSuccess }?: { onSuccess?: () => void }) => void;
   onButtonPress: () => void;
 }
 
 const ChamberOfSecrets = (props: Props) => {
-  const { navigation, createPin, createTxPassword, setIsTcAccepted, onButtonPress } = props;
+  const { createPin, createTxPassword, setIsTcAccepted, onButtonPress } = props;
 
   const [addWallet, setAddWallet] = useState(false);
   const [walletOptions, setWalletOptions] = useState({
@@ -80,18 +74,8 @@ const ChamberOfSecrets = (props: Props) => {
 
   const onPressSkipOnboardingButton = () => {
     setIsTcAccepted(true);
-
-    createPin(defaultPin, {
-      onSuccess: () => {
-        return;
-      },
-    });
-
-    createTxPassword(defaultTransactionPassword, {
-      onSuccess: () => {
-        navigation.navigate(Route.Dashboard);
-      },
-    });
+    createPin(defaultPin);
+    createTxPassword(defaultTransactionPassword);
 
     handleButtonPress();
   };

--- a/src/screens/ChamberOfSecrets.tsx
+++ b/src/screens/ChamberOfSecrets.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable react-native/no-raw-text */
-/* eslint-disable react-native/no-color-literals */
 /* eslint-disable react/no-unescaped-entities */
 import React, { useState } from 'react';
 import { StyleSheet, View } from 'react-native';
@@ -18,8 +17,12 @@ import {
 import { HEADER_HEIGHT } from 'app/components/Header';
 import { ImportWalletType, Wallet } from 'app/consts';
 import { HDSegwitP2SHArWallet, HDSegwitP2SHAirWallet } from 'app/legacy';
-import { createPin, createTxPassword, setIsTcAccepted } from 'app/state/authentication/actions';
-import { importWallet } from 'app/state/wallets/actions';
+import {
+  createPin as createPinAction,
+  createTxPassword as createTxPasswordAction,
+  createTc as createTcAction,
+} from 'app/state/authentication/actions';
+import { importWallet as importWalletAction } from 'app/state/wallets/actions';
 import { getStatusBarHeight, typography, palette } from 'app/styles';
 
 const i18n = require('../../loc');
@@ -35,29 +38,36 @@ const chamberOfSecretsGradient = {
   end: { x: 1, y: 1 },
 };
 
+const buttonLinearGradientProps = { colors: [...chamberOfSecretsGradient.colors].reverse() };
+
 interface Props {
   createPin: (value: string, { onSuccess }?: { onSuccess?: () => void }) => void;
   createTxPassword: (value: string, { onSuccess }?: { onSuccess?: () => void }) => void;
-  setIsTcAccepted: (value: boolean) => void;
+  createTc: (value: boolean) => void;
   importWallet: (wallet: Wallet, { onSuccess }?: { onSuccess?: () => void }) => void;
   onButtonPress: () => void;
+  credentials?: {
+    pin: string;
+    password: string;
+  };
 }
 
 const ChamberOfSecrets = (props: Props) => {
-  const { createPin, createTxPassword, setIsTcAccepted, onButtonPress } = props;
+  const {
+    createPin,
+    createTxPassword,
+    createTc,
+    onButtonPress,
+    credentials = { pin: '1234', password: 'qwertyui' },
+  } = props;
 
-  const [addWallet, setAddWallet] = useState(false);
+  const [isAddWalletChecked, setIsAddWalletChecked] = useState(false);
   const [walletOptions, setWalletOptions] = useState({
     type: 'Standard',
-    name: 'BAD MOTHER FUCKER',
+    name: 'My Wallet',
     seedPhrase:
       'innocent surge canoe iron nasty dinner aspect bar brand couch input embrace piano example panic champion aerobic debris search fly repeat sand nuclear tuition',
   });
-
-  const defaultPin = '1234';
-  const defaultTransactionPassword = 'qwertyui';
-
-  const buttonLinearGradientProps = { colors: [...chamberOfSecretsGradient.colors].reverse() };
 
   const handleButtonPress = () => {
     // TODO: To implement an import feature here the whole logic must be extracted from ImportWalletScreen first.
@@ -67,15 +77,15 @@ const ChamberOfSecrets = (props: Props) => {
   };
 
   const onPressSkipTermsConditionsButton = () => {
-    setIsTcAccepted(true);
+    createTc(true);
 
     handleButtonPress();
   };
 
   const onPressSkipOnboardingButton = () => {
-    setIsTcAccepted(true);
-    createPin(defaultPin);
-    createTxPassword(defaultTransactionPassword);
+    createTc(true);
+    createPin(credentials.pin);
+    createTxPassword(credentials.password);
 
     handleButtonPress();
   };
@@ -130,12 +140,12 @@ const ChamberOfSecrets = (props: Props) => {
 
       <CheckBox
         containerStyle={styles.checkboxContainer}
-        checked={addWallet}
+        checked={isAddWalletChecked}
         title="Create wallet?"
-        onPress={() => setAddWallet(!addWallet)}
+        onPress={() => setIsAddWalletChecked(!isAddWalletChecked)}
       />
 
-      {addWallet && (
+      {isAddWalletChecked && (
         <>
           <RadioButton
             testID="import-2-key-vault-radio"
@@ -219,4 +229,9 @@ const styles = StyleSheet.create({
   },
 });
 
-export default connect(null, { createPin, createTxPassword, setIsTcAccepted, importWallet })(ChamberOfSecrets);
+export default connect(null, {
+  createPin: createPinAction,
+  createTxPassword: createTxPasswordAction,
+  createTc: createTcAction,
+  importWallet: importWalletAction,
+})(ChamberOfSecrets);

--- a/src/screens/ChamberOfSecrets.tsx
+++ b/src/screens/ChamberOfSecrets.tsx
@@ -109,7 +109,7 @@ const ChamberOfSecrets = (props: Props) => {
         title="Skip Terms & Conditions"
         onPress={onPressSkipTermsConditionsButton}
         linearGradientProps={buttonLinearGradientProps}
-        style={styles.buttonStyle}
+        buttonStyle={styles.button}
       ></Button>
 
       <Button
@@ -117,7 +117,7 @@ const ChamberOfSecrets = (props: Props) => {
         title="Skip Onboarding"
         onPress={onPressSkipOnboardingButton}
         linearGradientProps={buttonLinearGradientProps}
-        style={styles.buttonStyle}
+        buttonStyle={styles.button}
       ></Button>
 
       <Button
@@ -125,7 +125,7 @@ const ChamberOfSecrets = (props: Props) => {
         title="Do nothing, just close it"
         onPress={() => handleButtonPress()}
         linearGradientProps={buttonLinearGradientProps}
-        style={styles.buttonStyle}
+        buttonStyle={styles.button}
       ></Button>
 
       <CheckBox
@@ -206,8 +206,9 @@ const styles = StyleSheet.create({
     textAlign: 'center',
     paddingBottom: 20,
   },
-  buttonStyle: {
+  button: {
     height: 43,
+    borderRadius: 21,
     marginBottom: 15,
   },
   checkboxContainer: {

--- a/src/screens/ChamberOfSecrets.tsx
+++ b/src/screens/ChamberOfSecrets.tsx
@@ -1,0 +1,237 @@
+/* eslint-disable react-native/no-raw-text */
+/* eslint-disable react-native/no-color-literals */
+/* eslint-disable react/no-unescaped-entities */
+import { CompositeNavigationProp } from '@react-navigation/native';
+import { StackNavigationProp } from '@react-navigation/stack';
+import React, { useState } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { connect } from 'react-redux';
+
+import {
+  Button,
+  CheckBox,
+  EllipsisText,
+  InputItem,
+  LinearGradient,
+  RadioButton,
+  ScreenTemplate,
+  Text,
+} from 'app/components';
+import { HEADER_HEIGHT } from 'app/components/Header';
+import { RootStackParams, Route, MainCardStackNavigatorParams, ImportWalletType, Wallet } from 'app/consts';
+import { HDSegwitP2SHArWallet, HDSegwitP2SHAirWallet } from 'app/legacy';
+import { createPin, createTxPassword, setIsTcAccepted } from 'app/state/authentication/actions';
+import { importWallet } from 'app/state/wallets/actions';
+import { getStatusBarHeight, typography, palette } from 'app/styles';
+
+const i18n = require('../../loc');
+
+const darkSlytherinColor = '#1a472a';
+const lightSlytherinColor = '#2a623d';
+
+const bloodColor = '#8A0303';
+
+const chamberOfSecretsGradient = {
+  colors: [darkSlytherinColor, lightSlytherinColor],
+  start: { x: 1, y: 0 },
+  end: { x: 1, y: 1 },
+};
+
+interface Props {
+  navigation: CompositeNavigationProp<
+    StackNavigationProp<RootStackParams, Route.MainCardStackNavigator>,
+    StackNavigationProp<MainCardStackNavigatorParams, Route.ConfirmPin>
+  >;
+  createPin: (value: string, { onSuccess }: { onSuccess: () => void }) => void;
+  createTxPassword: (value: string, { onSuccess }: { onSuccess: () => void }) => void;
+  setIsTcAccepted: (value: boolean) => void;
+  importWallet: (wallet: Wallet, { onSuccess }: { onSuccess: () => void }) => void;
+  onButtonPress: () => void;
+}
+
+const ChamberOfSecrets = (props: Props) => {
+  const { navigation, createPin, createTxPassword, setIsTcAccepted, onButtonPress } = props;
+
+  const [addWallet, setAddWallet] = useState(false);
+  const [walletOptions, setWalletOptions] = useState({
+    type: 'Standard',
+    name: 'BAD MOTHER FUCKER',
+    seedPhrase:
+      'innocent surge canoe iron nasty dinner aspect bar brand couch input embrace piano example panic champion aerobic debris search fly repeat sand nuclear tuition',
+  });
+
+  const defaultPin = '1234';
+  const defaultTransactionPassword = 'qwertyui';
+
+  const buttonLinearGradientProps = { colors: [...chamberOfSecretsGradient.colors].reverse() };
+
+  const handleButtonPress = () => {
+    // TODO: To implement an import feature here the whole logic must be extracted from ImportWalletScreen first.
+    // addWallet && importWallet({})
+
+    onButtonPress();
+  };
+
+  const onPressSkipTermsConditionsButton = () => {
+    setIsTcAccepted(true);
+
+    handleButtonPress();
+  };
+
+  const onPressSkipOnboardingButton = () => {
+    setIsTcAccepted(true);
+
+    createPin(defaultPin, {
+      onSuccess: () => {
+        return;
+      },
+    });
+
+    createTxPassword(defaultTransactionPassword, {
+      onSuccess: () => {
+        navigation.navigate(Route.Dashboard);
+      },
+    });
+
+    handleButtonPress();
+  };
+
+  const onWalletTypeSelect = (type: ImportWalletType) => setWalletOptions({ ...walletOptions, type });
+
+  const onWalletNameChange = (name: string) => setWalletOptions({ ...walletOptions, name });
+
+  const onSeedPhraseChange = (seedPhrase: string) => setWalletOptions({ ...walletOptions, seedPhrase });
+
+  const renderHeader = () => (
+    <LinearGradient {...chamberOfSecretsGradient} style={styles.headerContainer}>
+      <EllipsisText style={styles.title}>🔥 Chamber Of Secrets 🔥</EllipsisText>
+    </LinearGradient>
+  );
+
+  return (
+    <ScreenTemplate noScroll header={renderHeader()}>
+      <View style={styles.infoContainer}>
+        <Text style={styles.quoteHeading}>
+          "The Chamber of Secrets has been opened. Enemies of the heir... beware."
+        </Text>
+        <Text style={styles.disclaimerHeading}>
+          No worries though, it's just a joke, you're not in danger. It's a secret developer room created for testing
+          purposes. If you see it when you're not supposed to, please report it on GitHub or Telegram.
+        </Text>
+      </View>
+
+      <Button
+        testID="skip-terms-conditions-button"
+        title="Skip Terms & Conditions"
+        onPress={onPressSkipTermsConditionsButton}
+        linearGradientProps={buttonLinearGradientProps}
+        style={styles.buttonStyle}
+      ></Button>
+
+      <Button
+        testID="skip-onboarding-button"
+        title="Skip Onboarding"
+        onPress={onPressSkipOnboardingButton}
+        linearGradientProps={buttonLinearGradientProps}
+        style={styles.buttonStyle}
+      ></Button>
+
+      <Button
+        testID="close-chamber-button"
+        title="Do nothing, just close it"
+        onPress={() => handleButtonPress()}
+        linearGradientProps={buttonLinearGradientProps}
+        style={styles.buttonStyle}
+      ></Button>
+
+      <CheckBox
+        containerStyle={styles.checkboxContainer}
+        checked={addWallet}
+        title="Create wallet?"
+        onPress={() => setAddWallet(!addWallet)}
+      />
+
+      {addWallet && (
+        <>
+          <RadioButton
+            testID="import-2-key-vault-radio"
+            title={HDSegwitP2SHArWallet.typeReadable}
+            value="2-Key Vault"
+            checked={walletOptions.type === '2-Key Vault'}
+            onPress={onWalletTypeSelect}
+          />
+          <RadioButton
+            testID="import-3-key-vault-radio"
+            title={HDSegwitP2SHAirWallet.typeReadable}
+            value="3-Key Vault"
+            checked={walletOptions.type === '3-Key Vault'}
+            onPress={onWalletTypeSelect}
+          />
+          <RadioButton
+            testID="import-standard-wallet-radio"
+            title={i18n.wallets.add.legacyTitle}
+            value="Standard"
+            checked={walletOptions.type === 'Standard'}
+            onPress={onWalletTypeSelect}
+          />
+
+          <InputItem
+            testID="add-wallet-name-input"
+            value={walletOptions.name}
+            setValue={onWalletNameChange}
+            label="Wallet name"
+          />
+          <InputItem
+            testID="add-wallet-seed-phrase-input"
+            multiline
+            value={walletOptions.seedPhrase}
+            setValue={onSeedPhraseChange}
+            label="Seed phrase"
+          />
+        </>
+      )}
+    </ScreenTemplate>
+  );
+};
+
+const styles = StyleSheet.create({
+  headerContainer: {
+    paddingTop: getStatusBarHeight(),
+    height: HEADER_HEIGHT + getStatusBarHeight(),
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+    width: '100%',
+  },
+  title: {
+    ...typography.headline4,
+    color: palette.white,
+    paddingHorizontal: 40,
+  },
+  infoContainer: {
+    alignItems: 'center',
+  },
+  quoteHeading: {
+    ...typography.headline4,
+    color: bloodColor,
+    textAlign: 'center',
+    paddingBottom: 10,
+  },
+  disclaimerHeading: {
+    ...typography.headline7,
+    textAlign: 'center',
+    paddingBottom: 20,
+  },
+  buttonStyle: {
+    height: 43,
+    marginBottom: 15,
+  },
+  checkboxContainer: {
+    borderWidth: 0,
+    backgroundColor: palette.background,
+    marginLeft: 0,
+    paddingLeft: 0,
+  },
+});
+
+export default connect(null, { createPin, createTxPassword, setIsTcAccepted, importWallet })(ChamberOfSecrets);

--- a/src/screens/ChamberOfSecrets.tsx
+++ b/src/screens/ChamberOfSecrets.tsx
@@ -43,7 +43,7 @@ const buttonLinearGradientProps = { colors: [...chamberOfSecretsGradient.colors]
 interface Props {
   createPin: (value: string, { onSuccess }?: { onSuccess?: () => void }) => void;
   createTxPassword: (value: string, { onSuccess }?: { onSuccess?: () => void }) => void;
-  createTc: (value: boolean) => void;
+  createTc: () => void;
   importWallet: (wallet: Wallet, { onSuccess }?: { onSuccess?: () => void }) => void;
   onButtonPress: () => void;
   credentials?: {
@@ -77,13 +77,13 @@ const ChamberOfSecrets = (props: Props) => {
   };
 
   const onPressSkipTermsConditionsButton = () => {
-    createTc(true);
+    createTc();
 
     handleButtonPress();
   };
 
   const onPressSkipOnboardingButton = () => {
-    createTc(true);
+    createTc();
     createPin(credentials.pin);
     createTxPassword(credentials.password);
 

--- a/tests/e2e/pageObjects/index.ts
+++ b/tests/e2e/pageObjects/index.ts
@@ -3,6 +3,7 @@ import NavigationBar from './common/NavigationBar';
 import AddressBook from './pages/AddressBook';
 import Authenticators from './pages/Authenticators';
 import BetaVersionScreen from './pages/BetaVersionScreen';
+import DeveloperRoom from './pages/DeveloperRoom';
 import Onboarding from './pages/Onboarding';
 import Settings from './pages/Settings';
 import TermsConditionsScreen from './pages/TermsConditionsScreen';
@@ -10,6 +11,7 @@ import Wallets from './pages/Wallets';
 
 const app = {
   betaVersionScreen: BetaVersionScreen(),
+  developerRoom: DeveloperRoom(),
   onboarding: Onboarding(),
   wallets: Wallets(),
   authenticators: Authenticators(),

--- a/tests/e2e/pageObjects/pages/DeveloperRoom.ts
+++ b/tests/e2e/pageObjects/pages/DeveloperRoom.ts
@@ -1,0 +1,23 @@
+import { by, element } from 'detox';
+
+import actions from '../../actions';
+
+const DeveloperRoom = () => ({
+  skipTermsConditionsButton: element(by.id('skip-terms-conditions-button')),
+  skipOnboardingButton: element(by.id('skip-onboarding-button')),
+  doNothingButton: element(by.id('close-chamber-button')),
+
+  async tapOnSkipTermsConditionsButton() {
+    await actions.tap(this.skipTermsConditionsButton);
+  },
+
+  async tapOnSkipOnboardingButton() {
+    await actions.tap(this.skipOnboardingButton);
+  },
+
+  async tapOnDoNothingButton() {
+    await actions.tap(this.doNothingButton);
+  },
+});
+
+export default DeveloperRoom;

--- a/tests/e2e/specFiles/addressBook.spec.ts
+++ b/tests/e2e/specFiles/addressBook.spec.ts
@@ -6,9 +6,7 @@ import app from '../pageObjects';
 describe('Address book', () => {
   beforeEach(async () => {
     isBeta() && (await app.onboarding.betaVersionScreen.close());
-    await app.termsConditionsScreen.scrollDown();
-    await app.termsConditionsScreen.tapOnAgreeButton();
-    await app.onboarding.passThrough('1111', 'qwertyui');
+    await app.developerRoom.tapOnSkipOnboardingButton();
     await app.navigationBar.changeTab('address book');
   });
 

--- a/tests/e2e/specFiles/authenticators.spec.ts
+++ b/tests/e2e/specFiles/authenticators.spec.ts
@@ -6,9 +6,7 @@ import app from '../pageObjects';
 describe('Authenticators', () => {
   beforeEach(async () => {
     isBeta() && (await app.onboarding.betaVersionScreen.close());
-    await app.termsConditionsScreen.scrollDown();
-    await app.termsConditionsScreen.tapOnAgreeButton();
-    await app.onboarding.passThrough('1111', 'qwertyui');
+    await app.developerRoom.tapOnSkipOnboardingButton();
     await app.navigationBar.changeTab('authenticators');
   });
 

--- a/tests/e2e/specFiles/onboarding.spec.ts
+++ b/tests/e2e/specFiles/onboarding.spec.ts
@@ -5,8 +5,7 @@ import app from '../pageObjects';
 
 describe('Onboarding', () => {
   beforeEach(async () => {
-    await app.termsConditionsScreen.scrollDown();
-    await app.termsConditionsScreen.tapOnAgreeButton();
+    await app.developerRoom.tapOnSkipTermsConditionsButton();
   });
 
   describe('@android @ios @smoke', () => {

--- a/tests/e2e/specFiles/termsConditions.spec.ts
+++ b/tests/e2e/specFiles/termsConditions.spec.ts
@@ -1,11 +1,15 @@
 import { expect, waitFor } from 'detox';
 
 import { expectToBeDisabled } from '../assertions';
+import { isBeta } from '../helpers';
 import app from '../pageObjects';
 
 describe('Terms & Conditions', () => {
   describe('@android @ios @smoke', () => {
     it('should be possible to accept Terms & Conditions and proceed', async () => {
+      isBeta() && (await app.onboarding.betaVersionScreen.close());
+
+      await app.developerRoom.tapOnDoNothingButton();
       await app.termsConditionsScreen.scrollDown();
       await app.termsConditionsScreen.tapOnAgreeButton();
     });

--- a/tests/e2e/specFiles/wallets.spec.ts
+++ b/tests/e2e/specFiles/wallets.spec.ts
@@ -7,9 +7,7 @@ import app from '../pageObjects';
 describe('Wallets', () => {
   beforeEach(async () => {
     isBeta() && (await app.onboarding.betaVersionScreen.close());
-    await app.termsConditionsScreen.scrollDown();
-    await app.termsConditionsScreen.tapOnAgreeButton();
-    await app.onboarding.passThrough('1111', 'qwertyui');
+    await app.developerRoom.tapOnSkipOnboardingButton();
     await app.navigationBar.changeTab('wallets');
   });
 


### PR DESCRIPTION
## What does this PR do?

To make testing, both manual and automated, easier I implemented a "secret developer room" where a user can start the app with skipped onboarding. It's a problem especially when it comes to automated tests where scrolling Terms & Conditions down take forever.

To run the app with the secret screen you must provide an env variable `CHAMBER_OF_SECRETS=true` to `react-native start`

~End-to-end tests not updated yet, it must be done before the merge.~ Tests are updated.

Unfortunately, importing wallets on this screen isn't finished - the whole logic is implemented in `ImportWalletScreen` component and it must be extracted to another module first to make it possible.

![Simulator Screen Shot - iPhone 11 - 2020-12-22 at 18 06 37](https://user-images.githubusercontent.com/43886953/102916065-383f2900-4483-11eb-8f8a-19546a352c8e.png)
![Simulator Screen Shot - iPhone 11 - 2020-12-22 at 18 26 45](https://user-images.githubusercontent.com/43886953/102916108-4ee58000-4483-11eb-93f1-18d569c83017.png)

## Todos:

- [X] Checked on iOS
- [X] Checked on Android

## Required reviewers:
@KedziaPawel 
