### PR TITLE
Removed duplicated RNSentry module declaration

### DIFF
--- a/android/app/src/main/java/io/goldwallet/wallet/MainApplication.java
+++ b/android/app/src/main/java/io/goldwallet/wallet/MainApplication.java
@@ -11,8 +11,6 @@ import com.facebook.soloader.SoLoader;
 import io.goldwallet.PreventScreenshotPackage;
 import java.util.List;
 
-import io.sentry.react.RNSentryPackage;
-
 public class MainApplication extends Application implements ReactApplication {  
   private final ReactNativeHost mReactNativeHost = new ReactNativeHost(this) {
     @Override
@@ -27,7 +25,6 @@ public class MainApplication extends Application implements ReactApplication {
       // Packages that cannot be autolinked yet can be added manually here, for example:
       // packages.add(new MyReactNativePackage());
       packages.add(new PreventScreenshotPackage());
-      packages.add(new RNSentryPackage());
       
       return packages;
     }


### PR DESCRIPTION
## What does this PR do?

I haven't tested the changes I made on Android at all 🙈 and it turned out there's a bug. The app crashes on start due to duplicated RNSentry module declaration.

Here's the error:

![Screenshot_1609416110](https://user-images.githubusercontent.com/43886953/103409898-2dfaea00-4b69-11eb-9710-c957c302c197.png)

## Todos:

- [X] Checked on iOS
- [X] Checked on Android

## Required reviewers:
Anybody