### PR TITLE
Removed func with scroll to transaction note

### DIFF
--- a/tests/e2e/specFiles/Transactions/send.spec.ts
+++ b/tests/e2e/specFiles/Transactions/send.spec.ts
@@ -1,3 +1,5 @@
+import { expect } from 'detox';
+
 import { isBeta, createRandomNote, WALLETS_WITH_COINS, DEFAULT_TRANSACTION_PASSWORD } from '../../helpers';
 import app from '../../pageObjects';
 
@@ -33,14 +35,12 @@ describe('Transactions', () => {
         await app.transactionsSend.sendCoinsConfirmationScreen.tapSendButton();
         await app.transactionsSend.sendCoinsPasswordScreen.typePassword(DEFAULT_TRANSACTION_PASSWORD);
         await app.transactionsSend.sendCoinsPasswordScreen.tapConfirmPasswordButton();
-        await app.transactionsSend.successScreen.close();
-        await app.wallets.dashboardScreen.scrollToTheTransactionWithNote(transactionNote);
+        await expect(app.transactionsSend.successScreen.icon).toBeVisible();
       });
     });
 
     describe('@ios @regression', () => {
       it('should be possible to send coins from 3-Key Vault wallet (Fast Transaction) to 3-Key Vault wallet', async () => {
-        const transactionNote = createRandomNote();
         await app.wallets.importExistingWallet({
           type: '3-Key Vault',
           name: '3-Key wallet',
@@ -51,14 +51,12 @@ describe('Transactions', () => {
         await app.wallets.dashboardScreen.tapOnSendButton();
         await app.transactionsSend.sendCoinsMainScreen.typeCoinsAmountToSend(DATA_FOR_TRANSACTIONS.AMOUNT_TO_SEND);
         await app.transactionsSend.sendCoinsMainScreen.typeWalletAddress(DATA_FOR_TRANSACTIONS.WALLET_ADDRESS);
-        await app.transactionsSend.sendCoinsMainScreen.typeNote(transactionNote);
         await app.transactionsSend.sendCoinsMainScreen.chooseTransactionType('Secure Fast');
         await app.transactionsSend.sendCoinsMainScreen.tapNextButtton();
         await app.transactionsSend.sendCoinsConfirmationScreen.tapSendButton();
         await app.transactionsSend.sendCoinsPasswordScreen.typePassword(DEFAULT_TRANSACTION_PASSWORD);
         await app.transactionsSend.sendCoinsPasswordScreen.tapConfirmPasswordButton();
-        await app.transactionsSend.successScreen.close();
-        await app.wallets.dashboardScreen.scrollToTheTransactionWithNote(transactionNote);
+        await expect(app.transactionsSend.successScreen.icon).toBeVisible();
       });
     });
 
@@ -79,8 +77,7 @@ describe('Transactions', () => {
         await app.transactionsSend.sendCoinsConfirmationScreen.tapSendButton();
         await app.transactionsSend.sendCoinsPasswordScreen.typePassword(DEFAULT_TRANSACTION_PASSWORD);
         await app.transactionsSend.sendCoinsPasswordScreen.tapConfirmPasswordButton();
-        await app.transactionsSend.successScreen.close();
-        await app.wallets.dashboardScreen.scrollToTheTransactionWithNote(transactionNote);
+        await expect(app.transactionsSend.successScreen.icon).toBeVisible();
       });
     });
 
@@ -100,8 +97,7 @@ describe('Transactions', () => {
         await app.transactionsSend.sendCoinsConfirmationScreen.tapSendButton();
         await app.transactionsSend.sendCoinsPasswordScreen.typePassword(DEFAULT_TRANSACTION_PASSWORD);
         await app.transactionsSend.sendCoinsPasswordScreen.tapConfirmPasswordButton();
-        await app.transactionsSend.successScreen.close();
-        await app.wallets.dashboardScreen.scrollToTheTransactionWithNote(transactionNote);
+        await expect(app.transactionsSend.successScreen.icon).toBeVisible();
       });
     });
 
@@ -121,8 +117,7 @@ describe('Transactions', () => {
         await app.transactionsSend.sendCoinsConfirmationScreen.tapSendButton();
         await app.transactionsSend.sendCoinsPasswordScreen.typePassword(DEFAULT_TRANSACTION_PASSWORD);
         await app.transactionsSend.sendCoinsPasswordScreen.tapConfirmPasswordButton();
-        await app.transactionsSend.successScreen.close();
-        await app.wallets.dashboardScreen.scrollToTheTransactionWithNote(transactionNote);
+        await expect(app.transactionsSend.successScreen.icon).toBeVisible();
       });
     });
 
@@ -142,8 +137,7 @@ describe('Transactions', () => {
         await app.transactionsSend.sendCoinsConfirmationScreen.tapSendButton();
         await app.transactionsSend.sendCoinsPasswordScreen.typePassword(DEFAULT_TRANSACTION_PASSWORD);
         await app.transactionsSend.sendCoinsPasswordScreen.tapConfirmPasswordButton();
-        await app.transactionsSend.successScreen.close();
-        await app.wallets.dashboardScreen.scrollToTheTransactionWithNote(transactionNote);
+        await expect(app.transactionsSend.successScreen.icon).toBeVisible();
       });
     });
   });


### PR DESCRIPTION
## What does this PR do?
Removes scroll to transaction note function in `send.specs.ts` to improves the stability of UI tests for transactions.

## Todos:

- [x] Checked on iOS
- [ ] Checked on Android

## Required reviewers:
@marek-siemieniuk-morawski 