### PR TITLE
Fixed an import flow when email address is not configured yet

### DIFF
--- a/src/screens/ImportWalletScreen.tsx
+++ b/src/screens/ImportWalletScreen.tsx
@@ -170,44 +170,37 @@ export class ImportWalletScreen extends Component<Props, State> {
       });
     } else {
       newWallet.setLabel(this.state.label || i18n.wallets.import.imported + ' ' + newWallet.typeReadable);
-      // TODO: This part doesn't work when an email is not given while onboarding
-      // In this case, we do a request to backend with email: undefined.
-      // checkSubscription([newWallet], email, {
-      //   onSuccess: (ids: string[]) => {
-      //     const isWalletSubscribed = ids.some(id => id === newWallet.id);
-      //   },
-      // });
-      importWallet(newWallet, {
-        onSuccess: () => {
-          this.showSuccessImportMessageScreen();
-          // TODO: We shouldn't redirect to Route.CreateWalletSuccess but simply show SuccessMessage
-          // this.props.navigation.navigate(Route.CreateWalletSuccess, {
-          //   secret: newWallet.getSecret(),
-          //   onButtonPress: !!email
-          //     ? () =>
-          //         this.props.navigation.navigate(Route.Confirm, {
-          //           title: i18n.notifications.notifications,
-          //           children: this.renderConfirmScreenContent(),
-          //           onConfirm: () =>
-          //             this.props.navigation.navigate(Route.ConfirmEmail, {
-          //               email,
-          //               flowType: ConfirmAddressFlowType.SUBSCRIBE,
-          //               walletsToSubscribe: [newWallet],
-          //               onBack: () =>
-          //                 this.props.navigation.navigate(Route.WalletDetails, {
-          //                   id: newWallet.id,
-          //                 }),
-          //             }),
-          //           onBack: () =>
-          //             this.props.navigation.navigate(Route.MainTabStackNavigator, { screen: Route.Dashboard }),
-          //         })
-          //     : undefined,
-          // });
+      !email && this.showSuccessImportMessageScreen();
+      checkSubscription([newWallet], email, {
+        onSuccess: (ids: string[]) => {
+          const isWalletSubscribed = ids.some(id => id === newWallet.id);
+          importWallet(newWallet, {
+            onSuccess: () => {
+              !isWalletSubscribed
+                ? this.props.navigation.navigate(Route.Confirm, {
+                    title: i18n.notifications.notifications,
+                    children: this.renderConfirmScreenContent(),
+                    onConfirm: () =>
+                      this.props.navigation.navigate(Route.ConfirmEmail, {
+                        email,
+                        flowType: ConfirmAddressFlowType.SUBSCRIBE,
+                        walletsToSubscribe: [newWallet],
+                        onBack: () =>
+                          this.props.navigation.navigate(Route.WalletDetails, {
+                            id: newWallet.id,
+                          }),
+                      }),
+                    onBack: () =>
+                      this.props.navigation.navigate(Route.MainTabStackNavigator, { screen: Route.Dashboard }),
+                  })
+                : this.showSuccessImportMessageScreen();
+            },
+            onFailure: (error: string) =>
+              this.showErrorMessageScreen({
+                description: error,
+              }),
+          });
         },
-        onFailure: (error: string) =>
-          this.showErrorMessageScreen({
-            description: error,
-          }),
       });
     }
   };

--- a/src/screens/ImportWalletScreen.tsx
+++ b/src/screens/ImportWalletScreen.tsx
@@ -170,41 +170,41 @@ export class ImportWalletScreen extends Component<Props, State> {
       });
     } else {
       newWallet.setLabel(this.state.label || i18n.wallets.import.imported + ' ' + newWallet.typeReadable);
-      checkSubscription([newWallet], email, {
-        onSuccess: (ids: string[]) => {
-          const isWalletSubscribed = ids.some(id => id === newWallet.id);
-          importWallet(newWallet, {
-            onSuccess: () => {
-              this.props.navigation.navigate(Route.CreateWalletSuccess, {
-                secret: newWallet.getSecret(),
-                onButtonPress:
-                  !!email && !isWalletSubscribed
-                    ? () =>
-                        this.props.navigation.navigate(Route.Confirm, {
-                          title: i18n.notifications.notifications,
-                          children: this.renderConfirmScreenContent(),
-                          onConfirm: () =>
-                            this.props.navigation.navigate(Route.ConfirmEmail, {
-                              email,
-                              flowType: ConfirmAddressFlowType.SUBSCRIBE,
-                              walletsToSubscribe: [newWallet],
-                              onBack: () =>
-                                this.props.navigation.navigate(Route.WalletDetails, {
-                                  id: newWallet.id,
-                                }),
-                            }),
-                          onBack: () =>
-                            this.props.navigation.navigate(Route.MainTabStackNavigator, { screen: Route.Dashboard }),
-                        })
-                    : undefined,
-              });
-            },
-            onFailure: (error: string) =>
-              this.showErrorMessageScreen({
-                description: error,
-              }),
+      // TODO: This part doesn't work when an email is not given while onboarding
+      // checkSubscription([newWallet], email, {
+      //   onSuccess: (ids: string[]) => {
+      //     const isWalletSubscribed = ids.some(id => id === newWallet.id);
+      //   },
+      // });
+      importWallet(newWallet, {
+        onSuccess: () => {
+          this.props.navigation.navigate(Route.CreateWalletSuccess, {
+            secret: newWallet.getSecret(),
+            onButtonPress: !!email
+              ? () =>
+                  this.props.navigation.navigate(Route.Confirm, {
+                    title: i18n.notifications.notifications,
+                    children: this.renderConfirmScreenContent(),
+                    onConfirm: () =>
+                      this.props.navigation.navigate(Route.ConfirmEmail, {
+                        email,
+                        flowType: ConfirmAddressFlowType.SUBSCRIBE,
+                        walletsToSubscribe: [newWallet],
+                        onBack: () =>
+                          this.props.navigation.navigate(Route.WalletDetails, {
+                            id: newWallet.id,
+                          }),
+                      }),
+                    onBack: () =>
+                      this.props.navigation.navigate(Route.MainTabStackNavigator, { screen: Route.Dashboard }),
+                  })
+              : undefined,
           });
         },
+        onFailure: (error: string) =>
+          this.showErrorMessageScreen({
+            description: error,
+          }),
       });
     }
   };

--- a/src/screens/ImportWalletScreen.tsx
+++ b/src/screens/ImportWalletScreen.tsx
@@ -170,7 +170,16 @@ export class ImportWalletScreen extends Component<Props, State> {
       });
     } else {
       newWallet.setLabel(this.state.label || i18n.wallets.import.imported + ' ' + newWallet.typeReadable);
-      !email && this.showSuccessImportMessageScreen();
+      !email &&
+        importWallet(newWallet, {
+          onSuccess: () => {
+            this.showSuccessImportMessageScreen();
+          },
+          onFailure: (error: string) =>
+            this.showErrorMessageScreen({
+              description: error,
+            }),
+        });
       checkSubscription([newWallet], email, {
         onSuccess: (ids: string[]) => {
           const isWalletSubscribed = ids.some(id => id === newWallet.id);

--- a/src/screens/ImportWalletScreen.tsx
+++ b/src/screens/ImportWalletScreen.tsx
@@ -170,47 +170,47 @@ export class ImportWalletScreen extends Component<Props, State> {
       });
     } else {
       newWallet.setLabel(this.state.label || i18n.wallets.import.imported + ' ' + newWallet.typeReadable);
-      !email &&
-        importWallet(newWallet, {
-          onSuccess: () => {
-            this.showSuccessImportMessageScreen();
-          },
-          onFailure: (error: string) =>
-            this.showErrorMessageScreen({
-              description: error,
-            }),
-        });
-      checkSubscription([newWallet], email, {
-        onSuccess: (ids: string[]) => {
-          const isWalletSubscribed = ids.some(id => id === newWallet.id);
-          importWallet(newWallet, {
+      !email
+        ? importWallet(newWallet, {
             onSuccess: () => {
-              !isWalletSubscribed
-                ? this.props.navigation.navigate(Route.Confirm, {
-                    title: i18n.notifications.notifications,
-                    children: this.renderConfirmScreenContent(),
-                    onConfirm: () =>
-                      this.props.navigation.navigate(Route.ConfirmEmail, {
-                        email,
-                        flowType: ConfirmAddressFlowType.SUBSCRIBE,
-                        walletsToSubscribe: [newWallet],
-                        onBack: () =>
-                          this.props.navigation.navigate(Route.WalletDetails, {
-                            id: newWallet.id,
-                          }),
-                      }),
-                    onBack: () =>
-                      this.props.navigation.navigate(Route.MainTabStackNavigator, { screen: Route.Dashboard }),
-                  })
-                : this.showSuccessImportMessageScreen();
+              this.showSuccessImportMessageScreen();
             },
             onFailure: (error: string) =>
               this.showErrorMessageScreen({
                 description: error,
               }),
+          })
+        : checkSubscription([newWallet], email, {
+            onSuccess: (ids: string[]) => {
+              const isWalletSubscribed = ids.some(id => id === newWallet.id);
+              importWallet(newWallet, {
+                onSuccess: () => {
+                  !isWalletSubscribed
+                    ? this.props.navigation.navigate(Route.Confirm, {
+                        title: i18n.notifications.notifications,
+                        children: this.renderConfirmScreenContent(),
+                        onConfirm: () =>
+                          this.props.navigation.navigate(Route.ConfirmEmail, {
+                            email,
+                            flowType: ConfirmAddressFlowType.SUBSCRIBE,
+                            walletsToSubscribe: [newWallet],
+                            onBack: () =>
+                              this.props.navigation.navigate(Route.WalletDetails, {
+                                id: newWallet.id,
+                              }),
+                          }),
+                        onBack: () =>
+                          this.props.navigation.navigate(Route.MainTabStackNavigator, { screen: Route.Dashboard }),
+                      })
+                    : this.showSuccessImportMessageScreen();
+                },
+                onFailure: (error: string) =>
+                  this.showErrorMessageScreen({
+                    description: error,
+                  }),
+              });
+            },
           });
-        },
-      });
     }
   };
 

--- a/src/screens/ImportWalletScreen.tsx
+++ b/src/screens/ImportWalletScreen.tsx
@@ -171,6 +171,7 @@ export class ImportWalletScreen extends Component<Props, State> {
     } else {
       newWallet.setLabel(this.state.label || i18n.wallets.import.imported + ' ' + newWallet.typeReadable);
       // TODO: This part doesn't work when an email is not given while onboarding
+      // In this case, we do a request to backend with email: undefined.
       // checkSubscription([newWallet], email, {
       //   onSuccess: (ids: string[]) => {
       //     const isWalletSubscribed = ids.some(id => id === newWallet.id);
@@ -178,28 +179,30 @@ export class ImportWalletScreen extends Component<Props, State> {
       // });
       importWallet(newWallet, {
         onSuccess: () => {
-          this.props.navigation.navigate(Route.CreateWalletSuccess, {
-            secret: newWallet.getSecret(),
-            onButtonPress: !!email
-              ? () =>
-                  this.props.navigation.navigate(Route.Confirm, {
-                    title: i18n.notifications.notifications,
-                    children: this.renderConfirmScreenContent(),
-                    onConfirm: () =>
-                      this.props.navigation.navigate(Route.ConfirmEmail, {
-                        email,
-                        flowType: ConfirmAddressFlowType.SUBSCRIBE,
-                        walletsToSubscribe: [newWallet],
-                        onBack: () =>
-                          this.props.navigation.navigate(Route.WalletDetails, {
-                            id: newWallet.id,
-                          }),
-                      }),
-                    onBack: () =>
-                      this.props.navigation.navigate(Route.MainTabStackNavigator, { screen: Route.Dashboard }),
-                  })
-              : undefined,
-          });
+          this.showSuccessImportMessageScreen();
+          // TODO: We shouldn't redirect to Route.CreateWalletSuccess but simply show SuccessMessage
+          // this.props.navigation.navigate(Route.CreateWalletSuccess, {
+          //   secret: newWallet.getSecret(),
+          //   onButtonPress: !!email
+          //     ? () =>
+          //         this.props.navigation.navigate(Route.Confirm, {
+          //           title: i18n.notifications.notifications,
+          //           children: this.renderConfirmScreenContent(),
+          //           onConfirm: () =>
+          //             this.props.navigation.navigate(Route.ConfirmEmail, {
+          //               email,
+          //               flowType: ConfirmAddressFlowType.SUBSCRIBE,
+          //               walletsToSubscribe: [newWallet],
+          //               onBack: () =>
+          //                 this.props.navigation.navigate(Route.WalletDetails, {
+          //                   id: newWallet.id,
+          //                 }),
+          //             }),
+          //           onBack: () =>
+          //             this.props.navigation.navigate(Route.MainTabStackNavigator, { screen: Route.Dashboard }),
+          //         })
+          //     : undefined,
+          // });
         },
         onFailure: (error: string) =>
           this.showErrorMessageScreen({

--- a/src/screens/TermsConditionsScreen.tsx
+++ b/src/screens/TermsConditionsScreen.tsx
@@ -31,6 +31,7 @@ interface Props {
 interface State {
   showWarring: boolean;
   height: number;
+  isWebViewLoaded: boolean;
   agreedToTermsAndConditions: boolean;
   agreedToPrivacyPolicy: boolean;
 }
@@ -39,6 +40,7 @@ export class TermsConditionsScreen extends React.PureComponent<Props, State> {
   state = {
     showWarring: false,
     height: 500,
+    isWebViewLoaded: false,
     agreedToTermsAndConditions: false,
     agreedToPrivacyPolicy: false,
   };
@@ -159,6 +161,9 @@ export class TermsConditionsScreen extends React.PureComponent<Props, State> {
           scrollEnabled={false}
           automaticallyAdjustContentInsets={true}
           contentInset={{ top: 0, left: 0 }}
+          onLoad={() => {
+            this.setState({ isWebViewLoaded: true });
+          }}
           onNavigationStateChange={event => {
             if (event.title !== undefined) {
               this.setState({
@@ -174,22 +179,27 @@ export class TermsConditionsScreen extends React.PureComponent<Props, State> {
             return true;
           }}
         />
-        <CheckBox
-          onPress={this.toggleAgreementToTermsAndConditions}
-          containerStyle={styles.checkbox}
-          left
-          testID="terms-and-conditions-checkbox"
-          checked={agreedToTermsAndConditions}
-          title={<Text style={styles.checkboxText}>{i18n.termsConditions.readTermsConditions}</Text>}
-        />
-        <CheckBox
-          onPress={this.toggleAgreementToPrivacyPolicy}
-          containerStyle={styles.checkbox}
-          testID="privacy-policy-checkbox"
-          left
-          checked={agreedToPrivacyPolicy}
-          title={<Text style={styles.checkboxText}>{i18n.termsConditions.readPrivacyPolicy}</Text>}
-        />
+        {this.state.isWebViewLoaded && (
+          <>
+            <CheckBox
+              onPress={this.toggleAgreementToTermsAndConditions}
+              containerStyle={styles.checkbox}
+              left
+              testID="terms-and-conditions-checkbox"
+              checked={agreedToTermsAndConditions}
+              title={<Text style={styles.checkboxText}>{i18n.termsConditions.readTermsConditions}</Text>}
+            />
+            <CheckBox
+              onPress={this.toggleAgreementToPrivacyPolicy}
+              containerStyle={styles.checkbox}
+              testID="privacy-policy-checkbox"
+              left
+              checked={agreedToPrivacyPolicy}
+              title={<Text style={styles.checkboxText}>{i18n.termsConditions.readPrivacyPolicy}</Text>}
+            />
+          </>
+        )}
+
         <CustomModal show={showWarring}>{this.renderContent()}</CustomModal>
       </ScreenTemplate>
     );

--- a/tests/e2e/pageObjects/pages/TermsConditionsScreen.ts
+++ b/tests/e2e/pageObjects/pages/TermsConditionsScreen.ts
@@ -15,7 +15,10 @@ const TermsConditionsScreen = () => ({
   },
 
   async scrollDown() {
-    await actions.waitForElement(this.termsConditions);
+    await actions.scrollToElement(this.privacyPolicyCheckbox, 'terms-conditions-screen', {
+      direction: 'down',
+      pixels: 500,
+    });
     await this.termsConditions.scrollTo('bottom');
   },
 

--- a/tests/e2e/pageObjects/pages/TermsConditionsScreen.ts
+++ b/tests/e2e/pageObjects/pages/TermsConditionsScreen.ts
@@ -15,10 +15,6 @@ const TermsConditionsScreen = () => ({
   },
 
   async scrollDown() {
-    await actions.scrollToElement(this.privacyPolicyCheckbox, 'terms-conditions-screen', {
-      direction: 'down',
-      pixels: 500,
-    });
     await this.termsConditions.scrollTo('bottom');
   },
 

--- a/tests/e2e/specFiles/termsConditions.spec.ts
+++ b/tests/e2e/specFiles/termsConditions.spec.ts
@@ -1,5 +1,4 @@
-import { wait } from 'app/../utils/time';
-
+import { wait } from '../../../utils/time';
 import { expectToBeDisabled } from '../assertions';
 import { isBeta, SECOND } from '../helpers';
 import app from '../pageObjects';

--- a/tests/e2e/specFiles/termsConditions.spec.ts
+++ b/tests/e2e/specFiles/termsConditions.spec.ts
@@ -1,5 +1,7 @@
+import { wait } from 'app/../utils/time';
+
 import { expectToBeDisabled } from '../assertions';
-import { isBeta } from '../helpers';
+import { isBeta, SECOND } from '../helpers';
 import app from '../pageObjects';
 
 describe('Terms & Conditions', () => {
@@ -9,6 +11,8 @@ describe('Terms & Conditions', () => {
 
       await app.developerRoom.tapOnDoNothingButton();
 
+      // TODO: I am ashamed of it :(
+      await wait(10 * SECOND);
       await app.termsConditionsScreen.scrollDown();
       await app.termsConditionsScreen.tapOnAgreementCheckboxes();
       await app.termsConditionsScreen.tapOnAgreeButton();

--- a/tests/e2e/specFiles/termsConditions.spec.ts
+++ b/tests/e2e/specFiles/termsConditions.spec.ts
@@ -1,5 +1,3 @@
-import { expect, waitFor } from 'detox';
-
 import { expectToBeDisabled } from '../assertions';
 import { isBeta } from '../helpers';
 import app from '../pageObjects';
@@ -10,6 +8,7 @@ describe('Terms & Conditions', () => {
       isBeta() && (await app.onboarding.betaVersionScreen.close());
 
       await app.developerRoom.tapOnDoNothingButton();
+
       await app.termsConditionsScreen.scrollDown();
       await app.termsConditionsScreen.tapOnAgreementCheckboxes();
       await app.termsConditionsScreen.tapOnAgreeButton();


### PR DESCRIPTION
## What does this PR do?

Commented out a code that made it impossible to pass through an import flow if email address wasn't added during onboarding.

## Todos:

- [X] Checked on iOS
- [ ] Checked on Android
