### PR TITLE
Adds tests for receive section in transactions

### DIFF
--- a/src/consts/models.tsx
+++ b/src/consts/models.tsx
@@ -370,6 +370,8 @@ export type RootStackParams = {
     label: string;
     header?: React.ReactNode;
     value?: string;
+    inputTestID?: string;
+    submitButtonTestID?: string;
     validate?: (value: string) => string | undefined;
     validateOnSave?: (value: string) => void;
     keyboardType?: KeyboardType;

--- a/src/screens/EditTextScreen.tsx
+++ b/src/screens/EditTextScreen.tsx
@@ -19,6 +19,8 @@ export const EditTextScreen = (props: Props) => {
     header,
     onSave,
     title,
+    inputTestID,
+    submitButtonTestID,
     maxLength,
     checkZero,
     keyboardType = defaultKeyboardType,
@@ -57,12 +59,20 @@ export const EditTextScreen = (props: Props) => {
 
   return (
     <ScreenTemplate
-      footer={<Button title={i18n._.save} onPress={handlePressOnSaveButton} disabled={!canSubmit()} />}
+      footer={
+        <Button
+          testID={submitButtonTestID}
+          title={i18n._.save}
+          onPress={handlePressOnSaveButton}
+          disabled={!canSubmit()}
+        />
+      }
       header={<Header isBackArrow={true} title={title} />}
     >
       {header}
       <View style={styles.inputItemContainer}>
         <InputItem
+          testID={inputTestID}
           label={label}
           value={checkZero ? checkZero(value) : value}
           setValue={setValue}

--- a/src/screens/ReceiveCoinsScreen.tsx
+++ b/src/screens/ReceiveCoinsScreen.tsx
@@ -58,6 +58,8 @@ class ReceiveCoinsScreen extends Component<Props, State> {
 
   editAmount = () => {
     this.props.navigation.navigate(Route.EditText, {
+      submitButtonTestID: 'receive-submit-button',
+      inputTestID: 'receive-amount-input',
       title: i18n.receive.header,
       label: i18n.receive.details.amount,
       onSave: this.updateAmount,
@@ -135,6 +137,7 @@ class ReceiveCoinsScreen extends Component<Props, State> {
       <ScreenTemplate
         footer={
           <Button
+            testID="share-wallet-address-button"
             title={i18n.receive.details.shareWalletAddress}
             onPress={this.share}
             containerStyle={styles.buttonContainer}
@@ -148,7 +151,7 @@ class ReceiveCoinsScreen extends Component<Props, State> {
           label={wallet.label}
           unit={wallet.preferredBalanceUnit}
         />
-        <View style={styles.qrcontainer}>
+        <View testID="qr-code-icon" style={styles.qrcontainer}>
           {!!this.bip21encoded && (
             <QRCode
               quietZone={10}
@@ -162,12 +165,14 @@ class ReceiveCoinsScreen extends Component<Props, State> {
           )}
         </View>
         <Text style={styles.labelText}>{i18n.receive.label}:</Text>
-        <Text style={styles.address}>{this.message}</Text>
+        <Text testID="wallet-address-text" style={styles.address}>
+          {this.message}
+        </Text>
         <CopyButton textToCopy={this.message} />
         <Text style={styles.inputTitle}>{i18n.receive.details.receiveWithAmount}</Text>
         <Text style={styles.receiveSubtitle}>{i18n.receive.details.receiveWithAmountSubtitle}</Text>
         <View style={styles.amountInput}>
-          <Text style={styles.amount} onPress={this.editAmount}>
+          <Text testID="receive-amount-text" style={styles.amount} onPress={this.editAmount}>
             {amount ? amount.toString() : i18n.receive.details.amount}
           </Text>
         </View>

--- a/tests/e2e/pageObjects/index.ts
+++ b/tests/e2e/pageObjects/index.ts
@@ -6,6 +6,7 @@ import BetaVersionScreen from './pages/BetaVersionScreen';
 import DeveloperRoom from './pages/DeveloperRoom';
 import Onboarding from './pages/Onboarding';
 import TermsConditionsScreen from './pages/TermsConditionsScreen';
+import TransactionsReceive from './pages/Transactions/Receive';
 import TransactionsSend from './pages/Transactions/Send';
 import UnlockScreen from './pages/UnlockScreen';
 import Wallets from './pages/Wallets';
@@ -34,6 +35,7 @@ const app = {
   termsConditionsScreen: TermsConditionsScreen(),
   unlockScreen: UnlockScreen(),
   transactionsSend: TransactionsSend(),
+  transactionsReceive: TransactionsReceive(),
 };
 
 export default app;

--- a/tests/e2e/pageObjects/pages/Transactions/Receive.ts
+++ b/tests/e2e/pageObjects/pages/Transactions/Receive.ts
@@ -1,0 +1,20 @@
+import { by, element } from 'detox';
+
+import actions from '../../../actions';
+
+const ReceiveCoinsScreen = () => ({
+  shareWalletAddressButton: element(by.id('share-wallet-address-button')),
+  qrCodeIcon: element(by.id('qr-code-icon')),
+  walletAddressText: element(by.id('wallet-address-text')),
+  receiveAmountText: element(by.id('receive-amount-text')),
+  amountInput: element(by.id('receive-amount-input')),
+  submitAmountButton: element(by.id('receive-submit-button')),
+
+  async typeAmountToReceive(amount: string) {
+    await actions.tap(this.receiveAmountText);
+    await actions.typeText(this.amountInput, amount);
+    await actions.tap(this.submitAmountButton);
+  },
+});
+
+export default ReceiveCoinsScreen;

--- a/tests/e2e/pageObjects/pages/Transactions/Send.ts
+++ b/tests/e2e/pageObjects/pages/Transactions/Send.ts
@@ -33,7 +33,7 @@ const SendCoins = () => {
       await actions.tap(this.transactionTypeRadios[type]);
     },
 
-    async tapNextButtton() {
+    async tapNextButton() {
       await actions.tap(this.nextButton);
     },
   });

--- a/tests/e2e/pageObjects/pages/Wallets.ts
+++ b/tests/e2e/pageObjects/pages/Wallets.ts
@@ -31,6 +31,7 @@ const Wallets = () => {
     filterTransactionsButton: element(by.id('filter-transactions-button')),
     addButton: element(by.id('add-wallet-button')),
     sendButton: element(by.id('send-coins-button')),
+    recieveButton: element(by.id('receive-coins-button')),
 
     getTransactionElement: (note: string) => element(by.id(`transaction-item-${note}`)),
 
@@ -50,6 +51,10 @@ const Wallets = () => {
 
     async tapOnSendButton() {
       await actions.tap(this.sendButton);
+    },
+
+    async tapOnReceiveButton() {
+      await actions.tap(this.recieveButton);
     },
 
     async scrollToTheTransactionWithNote(note: string) {

--- a/tests/e2e/specFiles/Transactions/receive.spec.ts
+++ b/tests/e2e/specFiles/Transactions/receive.spec.ts
@@ -1,0 +1,117 @@
+import { expect } from 'detox';
+
+import { isBeta, WALLETS_WITH_COINS } from '../../helpers';
+import app from '../../pageObjects';
+
+const DATA_FOR_TRANSACTIONS = {
+  DEFAULT_VALUE: 'Amount',
+  AMOUNT_TO_RECEIVE: '10',
+};
+
+describe('Transactions', () => {
+  beforeEach(async () => {
+    isBeta() && (await app.onboarding.betaVersionScreen.close());
+    await app.developerRoom.tapOnSkipOnboardingButton();
+    await app.navigationBar.changeTab('wallets');
+  });
+
+  describe('Receive', () => {
+    describe('3-Key Vault', () => {
+      beforeEach(async () => {
+        await app.wallets.createWallet({
+          type: '3-Key Vault',
+          name: '3-Key',
+          fastPublicKey: WALLETS_WITH_COINS['3-Keys Vault'].FAST_KEY,
+          cancelPublicKey: WALLETS_WITH_COINS['3-Keys Vault'].CANCEL_KEY,
+        });
+      });
+      describe('@iOS @smoke', () => {
+        it('should be possible to see QRCode, wallet address and receive amount', async () => {
+          await app.wallets.dashboardScreen.tapOnReceiveButton();
+          await expect(app.transactionsReceive.qrCodeIcon).toBeVisible();
+          await expect(app.transactionsReceive.walletAddressText).toBeVisible();
+          await expect(app.transactionsReceive.receiveAmountText).toHaveText(DATA_FOR_TRANSACTIONS.DEFAULT_VALUE);
+          await app.transactionsReceive.typeAmountToReceive(DATA_FOR_TRANSACTIONS.AMOUNT_TO_RECEIVE);
+          await expect(app.transactionsReceive.receiveAmountText).toHaveText(DATA_FOR_TRANSACTIONS.AMOUNT_TO_RECEIVE);
+        });
+      });
+    });
+
+    describe('2-Key Vault', () => {
+      beforeEach(async () => {
+        await app.wallets.createWallet({
+          type: '2-Key Vault',
+          name: '2-Key',
+          cancelPublicKey: WALLETS_WITH_COINS['2-Keys Vault'].CANCEL_KEY,
+        });
+      });
+      describe('@iOS @regression', () => {
+        it('should be possible to see QRCode, wallet address and receive amount', async () => {
+          await app.wallets.dashboardScreen.tapOnReceiveButton();
+          await expect(app.transactionsReceive.qrCodeIcon).toBeVisible();
+          await expect(app.transactionsReceive.walletAddressText).toBeVisible();
+          await expect(app.transactionsReceive.receiveAmountText).toHaveText(DATA_FOR_TRANSACTIONS.DEFAULT_VALUE);
+          await app.transactionsReceive.typeAmountToReceive(DATA_FOR_TRANSACTIONS.AMOUNT_TO_RECEIVE);
+          await expect(app.transactionsReceive.receiveAmountText).toHaveText(DATA_FOR_TRANSACTIONS.AMOUNT_TO_RECEIVE);
+        });
+      });
+    });
+
+    describe('Standard HD P2SH', () => {
+      beforeEach(async () => {
+        await app.wallets.createWallet({
+          type: 'Standard HD P2SH',
+          name: 'Standard HD P2SH',
+        });
+      });
+      describe('@iOS @regression', () => {
+        it('should be possible to see QRCode, wallet address and receive amount', async () => {
+          await app.wallets.dashboardScreen.tapOnReceiveButton();
+          await expect(app.transactionsReceive.qrCodeIcon).toBeVisible();
+          await expect(app.transactionsReceive.walletAddressText).toBeVisible();
+          await expect(app.transactionsReceive.receiveAmountText).toHaveText(DATA_FOR_TRANSACTIONS.DEFAULT_VALUE);
+          await app.transactionsReceive.typeAmountToReceive(DATA_FOR_TRANSACTIONS.AMOUNT_TO_RECEIVE);
+          await expect(app.transactionsReceive.receiveAmountText).toHaveText(DATA_FOR_TRANSACTIONS.AMOUNT_TO_RECEIVE);
+        });
+      });
+    });
+
+    describe('Standard P2SH', () => {
+      beforeEach(async () => {
+        await app.wallets.createWallet({
+          type: 'Standard HD P2SH',
+          name: 'Standard P2SH',
+        });
+      });
+      describe('@iOS @regression', () => {
+        it('should be possible to see QRCode, wallet address and receive amount', async () => {
+          await app.wallets.dashboardScreen.tapOnReceiveButton();
+          await expect(app.transactionsReceive.qrCodeIcon).toBeVisible();
+          await expect(app.transactionsReceive.walletAddressText).toBeVisible();
+          await expect(app.transactionsReceive.receiveAmountText).toHaveText(DATA_FOR_TRANSACTIONS.DEFAULT_VALUE);
+          await app.transactionsReceive.typeAmountToReceive(DATA_FOR_TRANSACTIONS.AMOUNT_TO_RECEIVE);
+          await expect(app.transactionsReceive.receiveAmountText).toHaveText(DATA_FOR_TRANSACTIONS.AMOUNT_TO_RECEIVE);
+        });
+      });
+    });
+  });
+
+  describe('Standard HD SegWit', () => {
+    beforeEach(async () => {
+      await app.wallets.createWallet({
+        type: 'Standard HD P2SH',
+        name: 'Standard HD SegWit',
+      });
+    });
+    describe('@iOS @regression', () => {
+      it('should be possible to see QRCode, wallet address and receive amount', async () => {
+        await app.wallets.dashboardScreen.tapOnReceiveButton();
+        await expect(app.transactionsReceive.qrCodeIcon).toBeVisible();
+        await expect(app.transactionsReceive.walletAddressText).toBeVisible();
+        await expect(app.transactionsReceive.receiveAmountText).toHaveText(DATA_FOR_TRANSACTIONS.DEFAULT_VALUE);
+        await app.transactionsReceive.typeAmountToReceive(DATA_FOR_TRANSACTIONS.AMOUNT_TO_RECEIVE);
+        await expect(app.transactionsReceive.receiveAmountText).toHaveText(DATA_FOR_TRANSACTIONS.AMOUNT_TO_RECEIVE);
+      });
+    });
+  });
+});

--- a/tests/e2e/specFiles/Transactions/send.spec.ts
+++ b/tests/e2e/specFiles/Transactions/send.spec.ts
@@ -31,7 +31,7 @@ describe('Transactions', () => {
         await app.transactionsSend.sendCoinsMainScreen.typeWalletAddress(DATA_FOR_TRANSACTIONS.WALLET_ADDRESS);
         await app.transactionsSend.sendCoinsMainScreen.typeNote(transactionNote);
         await app.transactionsSend.sendCoinsMainScreen.chooseTransactionType('Secure');
-        await app.transactionsSend.sendCoinsMainScreen.tapNextButtton();
+        await app.transactionsSend.sendCoinsMainScreen.tapNextButton();
         await app.transactionsSend.sendCoinsConfirmationScreen.tapSendButton();
         await app.transactionsSend.sendCoinsPasswordScreen.typePassword(DEFAULT_TRANSACTION_PASSWORD);
         await app.transactionsSend.sendCoinsPasswordScreen.tapConfirmPasswordButton();
@@ -52,7 +52,7 @@ describe('Transactions', () => {
         await app.transactionsSend.sendCoinsMainScreen.typeCoinsAmountToSend(DATA_FOR_TRANSACTIONS.AMOUNT_TO_SEND);
         await app.transactionsSend.sendCoinsMainScreen.typeWalletAddress(DATA_FOR_TRANSACTIONS.WALLET_ADDRESS);
         await app.transactionsSend.sendCoinsMainScreen.chooseTransactionType('Secure Fast');
-        await app.transactionsSend.sendCoinsMainScreen.tapNextButtton();
+        await app.transactionsSend.sendCoinsMainScreen.tapNextButton();
         await app.transactionsSend.sendCoinsConfirmationScreen.tapSendButton();
         await app.transactionsSend.sendCoinsPasswordScreen.typePassword(DEFAULT_TRANSACTION_PASSWORD);
         await app.transactionsSend.sendCoinsPasswordScreen.tapConfirmPasswordButton();
@@ -73,7 +73,7 @@ describe('Transactions', () => {
         await app.transactionsSend.sendCoinsMainScreen.typeCoinsAmountToSend(DATA_FOR_TRANSACTIONS.AMOUNT_TO_SEND);
         await app.transactionsSend.sendCoinsMainScreen.typeWalletAddress(DATA_FOR_TRANSACTIONS.WALLET_ADDRESS);
         await app.transactionsSend.sendCoinsMainScreen.typeNote(transactionNote);
-        await app.transactionsSend.sendCoinsMainScreen.tapNextButtton();
+        await app.transactionsSend.sendCoinsMainScreen.tapNextButton();
         await app.transactionsSend.sendCoinsConfirmationScreen.tapSendButton();
         await app.transactionsSend.sendCoinsPasswordScreen.typePassword(DEFAULT_TRANSACTION_PASSWORD);
         await app.transactionsSend.sendCoinsPasswordScreen.tapConfirmPasswordButton();
@@ -93,7 +93,7 @@ describe('Transactions', () => {
         await app.transactionsSend.sendCoinsMainScreen.typeCoinsAmountToSend(DATA_FOR_TRANSACTIONS.AMOUNT_TO_SEND);
         await app.transactionsSend.sendCoinsMainScreen.typeWalletAddress(DATA_FOR_TRANSACTIONS.WALLET_ADDRESS);
         await app.transactionsSend.sendCoinsMainScreen.typeNote(transactionNote);
-        await app.transactionsSend.sendCoinsMainScreen.tapNextButtton();
+        await app.transactionsSend.sendCoinsMainScreen.tapNextButton();
         await app.transactionsSend.sendCoinsConfirmationScreen.tapSendButton();
         await app.transactionsSend.sendCoinsPasswordScreen.typePassword(DEFAULT_TRANSACTION_PASSWORD);
         await app.transactionsSend.sendCoinsPasswordScreen.tapConfirmPasswordButton();
@@ -113,7 +113,7 @@ describe('Transactions', () => {
         await app.transactionsSend.sendCoinsMainScreen.typeCoinsAmountToSend(DATA_FOR_TRANSACTIONS.AMOUNT_TO_SEND);
         await app.transactionsSend.sendCoinsMainScreen.typeWalletAddress(DATA_FOR_TRANSACTIONS.WALLET_ADDRESS);
         await app.transactionsSend.sendCoinsMainScreen.typeNote(transactionNote);
-        await app.transactionsSend.sendCoinsMainScreen.tapNextButtton();
+        await app.transactionsSend.sendCoinsMainScreen.tapNextButton();
         await app.transactionsSend.sendCoinsConfirmationScreen.tapSendButton();
         await app.transactionsSend.sendCoinsPasswordScreen.typePassword(DEFAULT_TRANSACTION_PASSWORD);
         await app.transactionsSend.sendCoinsPasswordScreen.tapConfirmPasswordButton();
@@ -133,7 +133,7 @@ describe('Transactions', () => {
         await app.transactionsSend.sendCoinsMainScreen.typeCoinsAmountToSend(DATA_FOR_TRANSACTIONS.AMOUNT_TO_SEND);
         await app.transactionsSend.sendCoinsMainScreen.typeWalletAddress(DATA_FOR_TRANSACTIONS.WALLET_ADDRESS);
         await app.transactionsSend.sendCoinsMainScreen.typeNote(transactionNote);
-        await app.transactionsSend.sendCoinsMainScreen.tapNextButtton();
+        await app.transactionsSend.sendCoinsMainScreen.tapNextButton();
         await app.transactionsSend.sendCoinsConfirmationScreen.tapSendButton();
         await app.transactionsSend.sendCoinsPasswordScreen.typePassword(DEFAULT_TRANSACTION_PASSWORD);
         await app.transactionsSend.sendCoinsPasswordScreen.tapConfirmPasswordButton();


### PR DESCRIPTION
## What does this PR do?

- Adds UI tests for receive section in transactions flow.
- Removing typo naming for `tapNextButton()` in `transactions/send`.

## Todos:

- [x] Checked on iOS
- [x] Checked on Android

## Required reviewers:
@marek-siemieniuk-morawski 