### PR TITLE
Add loading and error state to onboarding

### DIFF
--- a/src/helpers/reduxPersist.ts
+++ b/src/helpers/reduxPersist.ts
@@ -2,5 +2,7 @@ import AsyncStorage from '@react-native-community/async-storage';
 import { Reducer } from 'redux';
 import { persistReducer, PersistConfig } from 'redux-persist';
 
-export const createPersistReducer = (reducer: Reducer, config: Omit<PersistConfig<any, any, any, any>, 'storage'>) =>
+import { ApplicationState } from 'app/state';
+
+export const createPersistReducer = (reducer: Reducer, config: Omit<PersistConfig<ApplicationState>, 'storage'>) =>
   persistReducer({ ...config, storage: AsyncStorage }, reducer);

--- a/src/helpers/reduxPersist.ts
+++ b/src/helpers/reduxPersist.ts
@@ -1,0 +1,6 @@
+import AsyncStorage from '@react-native-community/async-storage';
+import { Reducer } from 'redux';
+import { persistReducer, PersistConfig } from 'redux-persist';
+
+export const createPersistReducer = (reducer: Reducer, config: Omit<PersistConfig<any, any, any, any>, 'storage'>) =>
+  persistReducer({ ...config, storage: AsyncStorage }, reducer);

--- a/src/screens/AddNotificationEmailScreen.tsx
+++ b/src/screens/AddNotificationEmailScreen.tsx
@@ -47,6 +47,10 @@ class AddNotificationEmailScreen extends PureComponent<Props, State> {
     email: '',
   };
 
+  componentDidMount() {
+    this.props.setError('');
+  }
+
   setEmail = (email: string): void => {
     this.setState({
       email,

--- a/src/screens/LocalConfirmNotificationCodeScreen.tsx
+++ b/src/screens/LocalConfirmNotificationCodeScreen.tsx
@@ -11,6 +11,8 @@ import { selectors as notificationSelectors } from 'app/state/notifications';
 import {
   verifyNotificationEmail as verifyNotificationEmailAction,
   VerifyNotificationEmailActionFunction,
+  SetErrorActionFunction,
+  setError as setErrorAction,
 } from 'app/state/notifications/actions';
 import { palette, typography } from 'app/styles';
 
@@ -19,7 +21,6 @@ const i18n = require('../../loc');
 type State = {
   userCode: string;
   numberAttempt: number;
-  localError: string;
 };
 
 interface Props {
@@ -28,6 +29,7 @@ interface Props {
   pin: string;
   error: string;
   email: string;
+  setError: SetErrorActionFunction;
   verifyNotificationEmail: VerifyNotificationEmailActionFunction;
 }
 
@@ -35,21 +37,24 @@ class LocalConfirmNotificationCodeScreen extends PureComponent<Props, State> {
   state = {
     userCode: '',
     numberAttempt: 0,
-    localError: '',
   };
+
+  componentWillUnmount() {
+    this.props.setError('');
+  }
 
   setCode = (userCode: string) => {
     this.setState({ userCode });
   };
 
   resendCode = (error = '') => {
-    const { verifyNotificationEmail } = this.props;
+    const { verifyNotificationEmail, setError } = this.props;
     const { email } = this.props.route.params;
 
     verifyNotificationEmail(email, {
       onSuccess: () => {
+        setError(error);
         this.setState({
-          localError: error,
           userCode: '',
           numberAttempt: 0,
         });
@@ -63,11 +68,13 @@ class LocalConfirmNotificationCodeScreen extends PureComponent<Props, State> {
     if (numberFail === CONST.emailCodeErrorMax) {
       this.resendCode(i18n.onboarding.resendCodeError);
     } else {
-      this.setState({
-        numberAttempt: numberFail,
-        localError: i18n.formatString(i18n.onboarding.validationCodeError, {
+      this.props.setError(
+        i18n.formatString(i18n.onboarding.validationCodeError, {
           numberAttempt: CONST.emailCodeErrorMax - numberFail,
         }),
+      );
+      this.setState({
+        numberAttempt: numberFail,
         userCode: '',
       });
     }
@@ -88,15 +95,9 @@ class LocalConfirmNotificationCodeScreen extends PureComponent<Props, State> {
     }
   };
 
-  get error() {
-    const { error } = this.props;
-    const { localError } = this.state;
-
-    return error || localError;
-  }
-
   render() {
     const { userCode, numberAttempt } = this.state;
+    const { error } = this.props;
     const { children, title } = this.props.route.params;
     const allowConfirm = numberAttempt < CONST.emailCodeErrorMax;
 
@@ -127,7 +128,7 @@ class LocalConfirmNotificationCodeScreen extends PureComponent<Props, State> {
         <View style={styles.codeContainer}>
           <CodeInput value={this.state.userCode} testID="confirm-code" onTextChange={this.setCode} />
           <Text testID="invalid-code-message" style={styles.errorText}>
-            {this.error}
+            {error}
           </Text>
         </View>
       </ScreenTemplate>
@@ -142,6 +143,7 @@ const mapStateToProps = (state: ApplicationState) => ({
 
 const mapDispatchToProps = {
   verifyNotificationEmail: verifyNotificationEmailAction,
+  setError: setErrorAction,
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(LocalConfirmNotificationCodeScreen);

--- a/src/state/notifications/actions.ts
+++ b/src/state/notifications/actions.ts
@@ -21,8 +21,13 @@ export enum NotificationAction {
   CheckSubscriptionAction = 'CheckSubscriptionAction',
   CheckSubscriptionSuccessAction = 'CheckSubscriptionSuccessAction',
   CheckSubscriptionFailureAction = 'CheckSubscriptionFailureAction',
+  SetErrorAction = 'SetErrorAction',
 }
 
+export interface SetErrorAction {
+  type: NotificationAction.SetErrorAction;
+  error: string;
+}
 export interface CreateNotificationEmailAction {
   type: NotificationAction.CreateNotificationEmail;
   payload: {
@@ -145,9 +150,11 @@ export type NotificationActionType =
   | AuthenticateEmailFailureAction
   | CheckSubscriptionAction
   | CheckSubscriptionSuccessAction
-  | CheckSubscriptionFailureAction;
+  | CheckSubscriptionFailureAction
+  | SetErrorAction;
 
-export const createNotificationEmail = (email: string, meta?: ActionMeta): CreateNotificationEmailAction => ({
+export type CreateNotificationEmailActionFunction = (email: string, meta?: ActionMeta) => CreateNotificationEmailAction;
+export const createNotificationEmail: CreateNotificationEmailActionFunction = (email, meta) => ({
   type: NotificationAction.CreateNotificationEmail,
   payload: { email },
   meta,
@@ -248,5 +255,11 @@ export const checkSubscriptionSuccess = (subscribedIds: string[]): CheckSubscrip
 
 export const checkSubscriptionFailure = (error: string): CheckSubscriptionFailureAction => ({
   type: NotificationAction.CheckSubscriptionFailureAction,
+  error,
+});
+
+export type SetErrorActionFunction = (error: string) => SetErrorAction;
+export const setError: SetErrorActionFunction = error => ({
+  type: NotificationAction.SetErrorAction,
   error,
 });

--- a/src/state/notifications/reducer.ts
+++ b/src/state/notifications/reducer.ts
@@ -1,4 +1,8 @@
+import { createPersistReducer } from 'app/helpers/reduxPersist';
+
 import { NotificationAction, NotificationActionType } from './actions';
+
+export const NOTIFICATIONS_REDUCER_NAME = 'notifications';
 
 export interface NotificationState {
   email: string;
@@ -15,12 +19,12 @@ const initialState: NotificationState = {
   email: '',
   pin: '',
   isNotificationEmailSet: false,
-  isLoading: true,
+  isLoading: false,
   sessionToken: '',
   subscribedIds: [],
 };
 
-export const notificationReducer = (state = initialState, action: NotificationActionType): NotificationState => {
+const reducer = (state = initialState, action: NotificationActionType): NotificationState => {
   switch (action.type) {
     case NotificationAction.CreateNotificationEmailSuccess:
       return {
@@ -36,16 +40,23 @@ export const notificationReducer = (state = initialState, action: NotificationAc
       return {
         ...state,
         error: action.error,
+        isLoading: false,
       };
     case NotificationAction.DeleteNotificationEmailAction:
       return {
         ...state,
         email: '',
       };
+    case NotificationAction.VerifyNotificationEmailAction:
+      return {
+        ...state,
+        isLoading: true,
+      };
     case NotificationAction.VerifyNotificationEmailActionSuccess:
       return {
         ...state,
         pin: action.payload.pin,
+        isLoading: false,
       };
     case NotificationAction.SubscribeWalletSuccessAction:
       return {
@@ -66,6 +77,7 @@ export const notificationReducer = (state = initialState, action: NotificationAc
     case NotificationAction.UnsubscribeWalletFailureAction:
     case NotificationAction.AuthenticateEmailFailureAction:
     case NotificationAction.CheckSubscriptionFailureAction:
+    case NotificationAction.SetErrorAction:
       return {
         ...state,
         error: action.error,
@@ -81,3 +93,8 @@ export const notificationReducer = (state = initialState, action: NotificationAc
       return state;
   }
 };
+
+export const notificationReducer = createPersistReducer(reducer, {
+  key: NOTIFICATIONS_REDUCER_NAME,
+  whitelist: ['email', 'isNotificationEmailSet'],
+});

--- a/src/state/notifications/selectors.ts
+++ b/src/state/notifications/selectors.ts
@@ -24,6 +24,7 @@ export const readableError = createSelector(notificationError, err => {
   }
   return err;
 });
+export const isLoading = createSelector(local, state => state.isLoading);
 
 export const isWalletSubscribed = createSelector(
   subscribedIds,

--- a/src/state/rootReducer.ts
+++ b/src/state/rootReducer.ts
@@ -8,7 +8,7 @@ import { AuthenticatorsState, authenticatorsReducer } from './authenticators/red
 import { contactsReducer, ContactsState } from './contacts/reducer';
 import { ElectrumXState, electrumXReducer } from './electrumX/reducer';
 import { filtersReducer } from './filters/reducer';
-import { NotificationState, notificationReducer } from './notifications/reducer';
+import { NotificationState, notificationReducer, NOTIFICATIONS_REDUCER_NAME } from './notifications/reducer';
 import { TimeCounterState, timeCounterReducer } from './timeCounter/reducer';
 import { ToastMessagesState, toastMessageReducer } from './toastMessages/reducer';
 import { transactionsNotesReducer, TransactionsNotesState } from './transactionsNotes/reducer';
@@ -40,5 +40,5 @@ export const rootReducer = combineReducers({
   authentication: authenticationReducer,
   filters: filtersReducer,
   toastMessages: toastMessageReducer,
-  notifications: notificationReducer,
+  [NOTIFICATIONS_REDUCER_NAME]: notificationReducer,
 });

--- a/src/state/rootReducer.ts
+++ b/src/state/rootReducer.ts
@@ -1,6 +1,7 @@
 import { combineReducers } from 'redux';
 
 import { Filters } from 'app/consts';
+import { createPersistReducer } from 'app/helpers/reduxPersist';
 
 import { appSettingsReducer, AppSettingsState } from './appSettings/reducer';
 import { AuthenticationState, authenticationReducer } from './authentication/reducer';
@@ -29,7 +30,20 @@ export interface ApplicationState {
   notifications: NotificationState;
 }
 
-export const rootReducer = combineReducers({
+const persistConfig = {
+  key: 'root',
+  blacklist: [
+    'wallets',
+    'authenticators',
+    'authentication',
+    'electrumX',
+    'filters',
+    'toastMessages',
+    NOTIFICATIONS_REDUCER_NAME,
+  ],
+};
+
+const rootReducer = combineReducers({
   contacts: contactsReducer,
   transactions: transactionsNotesReducer,
   appSettings: appSettingsReducer,
@@ -42,3 +56,5 @@ export const rootReducer = combineReducers({
   toastMessages: toastMessageReducer,
   [NOTIFICATIONS_REDUCER_NAME]: notificationReducer,
 });
+
+export const persistedReducer = createPersistReducer(rootReducer, persistConfig);

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -1,7 +1,8 @@
-import AsyncStorage from '@react-native-community/async-storage';
 import { applyMiddleware, compose, createStore, Middleware, Store } from 'redux';
-import { persistReducer, persistStore } from 'redux-persist';
+import { persistStore } from 'redux-persist';
 import createSagaMiddleware from 'redux-saga';
+
+import { createPersistReducer } from 'app/helpers/reduxPersist';
 
 import { rootReducer, ApplicationState, rootSaga } from '.';
 
@@ -21,11 +22,10 @@ function bindMiddleware(middleware: Middleware[]) {
 
 const persistConfig = {
   key: 'root',
-  storage: AsyncStorage,
-  blacklist: ['wallets', 'authenticators', 'authentication', 'electrumX', 'filters', 'toastMessages'],
+  blacklist: ['wallets', 'authenticators', 'authentication', 'electrumX', 'filters', 'toastMessages', 'notifications'],
 };
 
-const persistedReducer = persistReducer(persistConfig, rootReducer);
+const persistedReducer = createPersistReducer(rootReducer, persistConfig);
 
 const configureStore = (): Store<ApplicationState> => createStore(persistedReducer, bindMiddleware(middlewares));
 

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -2,9 +2,7 @@ import { applyMiddleware, compose, createStore, Middleware, Store } from 'redux'
 import { persistStore } from 'redux-persist';
 import createSagaMiddleware from 'redux-saga';
 
-import { createPersistReducer } from 'app/helpers/reduxPersist';
-
-import { rootReducer, ApplicationState, rootSaga } from '.';
+import { persistedReducer, ApplicationState, rootSaga } from '.';
 
 const sagaMiddleware = createSagaMiddleware();
 
@@ -19,13 +17,6 @@ function bindMiddleware(middleware: Middleware[]) {
 
   return applyMiddleware(...middlewares);
 }
-
-const persistConfig = {
-  key: 'root',
-  blacklist: ['wallets', 'authenticators', 'authentication', 'electrumX', 'filters', 'toastMessages', 'notifications'],
-};
-
-const persistedReducer = createPersistReducer(rootReducer, persistConfig);
 
 const configureStore = (): Store<ApplicationState> => createStore(persistedReducer, bindMiddleware(middlewares));
 


### PR DESCRIPTION
## What does this PR do?

It adds missing loading and errors states for onboarding

#### *Any scout cleaning/refactoring?*
Deleted "localError", now errors are taken only from redux so we have a single source of truth.
Notifications state persists only chosen values. We should from now on store explicit values as there is a problem with values that shouldn't be stored, like "isLoading", for example after relaunching the app we can get isLoading true even if no action was fired

#### *Any blog post related to the solution you have used?*
https://github.com/rt2zz/redux-persist

- [ ] Checked on iOS
- [X] Checked on Android

