### PR TITLE
Add resend and error handling for code confirm screen

### DIFF
--- a/error/messages.ts
+++ b/error/messages.ts
@@ -6,4 +6,5 @@ export default {
   requestFailed5XX: 'Request failed with status code 5',
   alreadySubscribed: "{'hash': [ErrorDetail(string='wallet with this hash already exists.', code='unique')]}",
   invalidEmail: "Bad request: {'email': [ErrorDetail(string='Enter a valid email address.', code='invalid')]}",
+  wrongPIN: 'Wrong pin',
 };

--- a/src/components/TimeoutButton.tsx
+++ b/src/components/TimeoutButton.tsx
@@ -1,20 +1,27 @@
 import React, { useState, FC } from 'react';
 import { StyleSheet, GestureResponderEvent, ViewStyle, StyleProp } from 'react-native';
 
+import { CONST } from 'app/consts';
 import { useInterval } from 'app/helpers/useInterval';
 import { typography } from 'app/styles';
 
 import { FlatButton } from './FlatButton';
 
 interface Props {
-  timeoutSeconds: number;
+  timeoutSeconds?: number;
   title: string;
   testID?: string;
   onPress: (e?: GestureResponderEvent) => void;
   containerStyle?: StyleProp<ViewStyle>;
 }
 
-export const TimeoutButton: FC<Props> = ({ title, testID, timeoutSeconds, onPress, containerStyle }) => {
+export const TimeoutButton: FC<Props> = ({
+  title,
+  testID,
+  timeoutSeconds = CONST.buttonTimeoutSeconds,
+  onPress,
+  containerStyle,
+}) => {
   const [seconds, setSeconds] = useState(0);
   useInterval(
     () => {

--- a/src/consts/models.tsx
+++ b/src/consts/models.tsx
@@ -48,6 +48,7 @@ export const CONST = {
   walletsDefaultGapLimit: 20,
   userVersion: 'userVersion',
   newestUserVersion: last(Object.keys(USER_VERSIONS)) as USER_VERSIONS,
+  buttonTimeoutSeconds: 30,
 };
 
 export const ADDRESSES_TYPES = {
@@ -524,7 +525,7 @@ export type RootStackParams = {
     email: string;
     newAddress?: string;
     flowType: ConfirmAddressFlowType;
-    walletsToSubscribe?: Wallet[];
+    wallets?: Wallet[];
     onBack?: () => void;
     onSuccess: () => void;
   };

--- a/src/screens/AddNotificationEmailScreen.tsx
+++ b/src/screens/AddNotificationEmailScreen.tsx
@@ -96,8 +96,8 @@ class AddNotificationEmailScreen extends PureComponent<Props, State> {
     }
     checkSubscription(wallets, email, {
       onSuccess: (ids: string[]) => {
-        const walletsToSubscribe = wallets.filter(w => !ids.includes(w.id));
-        if (!walletsToSubscribe.length) {
+        const walletsToSubcribe = wallets.filter(w => !ids.includes(w.id));
+        if (!wallets.length) {
           return this.goToLocalEmailConfirm();
         }
         navigation.navigate(Route.ChooseWalletsForNotification, {
@@ -106,7 +106,7 @@ class AddNotificationEmailScreen extends PureComponent<Props, State> {
           description: i18n.notifications.chooseWalletsDescription,
           email,
           onSuccess,
-          wallets: walletsToSubscribe,
+          wallets: walletsToSubcribe,
           onSkip: () => this.goToLocalEmailConfirm(),
         });
       },
@@ -183,7 +183,7 @@ const mapDispatchToProps = {
 };
 
 const mapStateToProps = (state: ApplicationState) => ({
-  wallets: walletsSelectors.subscribableWallets(state),
+  wallets: walletsSelectors.wallets(state),
   isLoading: notificationsSelectors.isLoading(state),
   error: notificationsSelectors.notificationError(state),
 });

--- a/src/screens/AddNotificationEmailScreen.tsx
+++ b/src/screens/AddNotificationEmailScreen.tsx
@@ -96,8 +96,8 @@ class AddNotificationEmailScreen extends PureComponent<Props, State> {
     }
     checkSubscription(wallets, email, {
       onSuccess: (ids: string[]) => {
-        const walletsToSubcribe = wallets.filter(w => !ids.includes(w.id));
-        if (!wallets.length) {
+        const walletsToSubscribe = wallets.filter(w => !ids.includes(w.id));
+        if (!walletsToSubscribe.length) {
           return this.goToLocalEmailConfirm();
         }
         navigation.navigate(Route.ChooseWalletsForNotification, {
@@ -106,7 +106,7 @@ class AddNotificationEmailScreen extends PureComponent<Props, State> {
           description: i18n.notifications.chooseWalletsDescription,
           email,
           onSuccess,
-          wallets: walletsToSubcribe,
+          wallets: walletsToSubscribe,
           onSkip: () => this.goToLocalEmailConfirm(),
         });
       },

--- a/src/screens/AddNotificationEmailScreen.tsx
+++ b/src/screens/AddNotificationEmailScreen.tsx
@@ -14,10 +14,10 @@ import {
   verifyNotificationEmail as verifyNotificationEmailAction,
   checkSubscription as checkSubscriptionAction,
   CheckSubscriptionAction,
-  VerifyNotificationEmailActionFunction,
-  SetErrorActionFunction,
+  VerifyNotificationEmailActionCreator,
+  SetErrorActionCreator,
   setError as setErrorAction,
-  CreateNotificationEmailActionFunction,
+  CreateNotificationEmailActionCreator,
 } from 'app/state/notifications/actions';
 import { selectors as walletsSelectors } from 'app/state/wallets';
 import { typography, palette } from 'app/styles';
@@ -27,9 +27,9 @@ const i18n = require('../../loc');
 interface Props {
   navigation: StackNavigationProp<RootStackParams, Route.AddNotificationEmail>;
   route: RouteProp<RootStackParams, Route.AddNotificationEmail>;
-  createNotificationEmail: CreateNotificationEmailActionFunction;
-  setError: SetErrorActionFunction;
-  verifyNotificationEmail: VerifyNotificationEmailActionFunction;
+  createNotificationEmail: CreateNotificationEmailActionCreator;
+  setError: SetErrorActionCreator;
+  verifyNotificationEmail: VerifyNotificationEmailActionCreator;
   wallets: Wallet[];
   error: string;
   isLoading: boolean;

--- a/src/screens/CreateWalletScreen.tsx
+++ b/src/screens/CreateWalletScreen.tsx
@@ -109,7 +109,7 @@ export class CreateWalletScreen extends React.PureComponent<Props, State> {
         navigation.navigate(Route.ConfirmEmail, {
           email,
           flowType: ConfirmAddressFlowType.SUBSCRIBE,
-          walletsToSubscribe: [wallet],
+          wallets: [wallet],
           onSuccess: this.navigateToSuccesfullNotificationSubscriptionMessage,
         }),
       onBack: () => this.props.navigation.navigate(Route.MainTabStackNavigator, { screen: Route.Dashboard }),

--- a/src/screens/ImportWalletScreen.tsx
+++ b/src/screens/ImportWalletScreen.tsx
@@ -169,7 +169,7 @@ export class ImportWalletScreen extends Component<Props, State> {
         navigation.navigate(Route.ConfirmEmail, {
           email,
           flowType: ConfirmAddressFlowType.SUBSCRIBE,
-          walletsToSubscribe: [wallet],
+          wallets: [wallet],
           onSuccess: this.showSuccessImportMessageScreen,
         }),
       onBack: () => this.props.navigation.navigate(Route.MainTabStackNavigator, { screen: Route.Dashboard }),

--- a/src/screens/LocalConfirmNotificationCodeScreen.tsx
+++ b/src/screens/LocalConfirmNotificationCodeScreen.tsx
@@ -10,8 +10,8 @@ import { ApplicationState } from 'app/state';
 import { selectors as notificationSelectors } from 'app/state/notifications';
 import {
   verifyNotificationEmail as verifyNotificationEmailAction,
-  VerifyNotificationEmailActionFunction,
-  SetErrorActionFunction,
+  VerifyNotificationEmailActionCreator,
+  SetErrorActionCreator,
   setError as setErrorAction,
 } from 'app/state/notifications/actions';
 import { palette, typography } from 'app/styles';
@@ -29,8 +29,8 @@ interface Props {
   pin: string;
   error: string;
   email: string;
-  setError: SetErrorActionFunction;
-  verifyNotificationEmail: VerifyNotificationEmailActionFunction;
+  setError: SetErrorActionCreator;
+  verifyNotificationEmail: VerifyNotificationEmailActionCreator;
 }
 
 class LocalConfirmNotificationCodeScreen extends PureComponent<Props, State> {

--- a/src/screens/LocalConfirmNotificationCodeScreen.tsx
+++ b/src/screens/LocalConfirmNotificationCodeScreen.tsx
@@ -118,7 +118,6 @@ class LocalConfirmNotificationCodeScreen extends PureComponent<Props, State> {
               testID="resend-code-email"
               containerStyle={styles.resendButton}
               title={i18n.notifications.resend}
-              timeoutSeconds={30}
               onPress={() => this.resendCode()}
             />
           </>

--- a/src/screens/Notifications/ChooseWalletsForNotificationScreen.tsx
+++ b/src/screens/Notifications/ChooseWalletsForNotificationScreen.tsx
@@ -74,7 +74,7 @@ export class ChooseWalletsForNotificationScreen extends PureComponent<Props, Sta
       email: params.email,
       flowType: params.flowType,
       onSuccess: params.onSuccess,
-      walletsToSubscribe: params.wallets,
+      wallets: params.wallets,
     });
   };
 

--- a/src/screens/Notifications/ConfirmEmailScreen.tsx
+++ b/src/screens/Notifications/ConfirmEmailScreen.tsx
@@ -174,7 +174,7 @@ class ConfirmEmailScreen extends Component<Props, State> {
         </View>
         <View style={styles.inputItemContainer}>
           <CodeInput value={this.state.code} onTextChange={this.onChange} isError={!!notificationError} />
-          <Text style={styles.error}>{notificationError}</Text>
+          {notificationError && <Text style={styles.error}>{notificationError}</Text>}
         </View>
       </ScreenTemplate>
     );

--- a/src/screens/Notifications/ConfirmEmailScreen.tsx
+++ b/src/screens/Notifications/ConfirmEmailScreen.tsx
@@ -5,7 +5,7 @@ import React, { Component } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { connect } from 'react-redux';
 
-import { Header, ScreenTemplate, Button, FlatButton, CodeInput } from 'app/components';
+import { Header, ScreenTemplate, Button, CodeInput, TimeoutButton } from 'app/components';
 import { Route, RootStackParams, ConfirmAddressFlowType, CONST, ActionMeta, InfoContainerContent } from 'app/consts';
 import { ApplicationState } from 'app/state';
 import {
@@ -30,7 +30,6 @@ interface Props {
   subscribe: SubscribeWalletActionCreator;
   unsubscribe: UnsubscribeWalletActionCreator;
   authenticate: (session_token: string, pin: string, meta: ActionMeta) => AuthenticateEmailAction;
-  language: string;
   sessionToken: string;
   notificationError: string;
   storedEmail: string;
@@ -50,7 +49,7 @@ class ConfirmEmailScreen extends Component<Props, State> {
     failNo: 0,
   };
 
-  async componentDidMount() {
+  componentDidMount() {
     this.infoContainerContent.onInit?.();
   }
 
@@ -70,14 +69,14 @@ class ConfirmEmailScreen extends Component<Props, State> {
       createNotificationEmail,
       storedEmail,
       route: {
-        params: { email, walletsToSubscribe, onSuccess },
+        params: { email, wallets, onSuccess },
       },
     } = this.props;
     return {
       title: i18n.notifications.verifyAction,
       description: i18n.notifications.verifyActionDescription,
       onInit: () => {
-        walletsToSubscribe && this.props.subscribe(walletsToSubscribe, email);
+        wallets && this.props.subscribe(wallets, email);
       },
       onCodeConfirm: () => {
         if (storedEmail) {
@@ -91,14 +90,14 @@ class ConfirmEmailScreen extends Component<Props, State> {
   unsubscribeFlowContent = () => {
     const {
       route: {
-        params: { email, walletsToSubscribe, onSuccess },
+        params: { email, wallets, onSuccess },
       },
     } = this.props;
     return {
       title: i18n.notifications.verifyAction,
       description: i18n.notifications.verifyActionDescription,
       onInit: () => {
-        walletsToSubscribe && this.props.unsubscribe(walletsToSubscribe, email);
+        wallets && this.props.unsubscribe(wallets, email);
       },
       onCodeConfirm: () => {
         onSuccess();
@@ -145,7 +144,9 @@ class ConfirmEmailScreen extends Component<Props, State> {
   onChange = (code: string) =>
     this.setState({ code, error: '', failNo: this.state.failNo >= CONST.emailCodeErrorMax ? 0 : this.state.failNo });
 
-  onResend = () => {};
+  onResend = () => {
+    this.infoContainerContent.onInit?.();
+  };
 
   render() {
     const { email, onBack } = this.props.route.params;
@@ -160,11 +161,12 @@ class ConfirmEmailScreen extends Component<Props, State> {
               onPress={this.onConfirm}
               disabled={this.state.code.length !== CONST.codeLength}
             />
-            {/* <FlatButton // uncomment when api for resend works
+            <TimeoutButton
+              testID="resend-code-email"
               containerStyle={styles.resendButton}
               title={i18n.notifications.resend}
               onPress={this.onResend}
-            />  TODO uncomment when resend is ready on backend */}
+            />
           </>
         }
       >

--- a/src/screens/Notifications/ConfirmEmailScreen.tsx
+++ b/src/screens/Notifications/ConfirmEmailScreen.tsx
@@ -6,13 +6,13 @@ import { View, Text, StyleSheet } from 'react-native';
 import { connect } from 'react-redux';
 
 import { Header, ScreenTemplate, Button, CodeInput, TimeoutButton } from 'app/components';
-import { Route, RootStackParams, ConfirmAddressFlowType, CONST, ActionMeta, InfoContainerContent } from 'app/consts';
+import { Route, RootStackParams, ConfirmAddressFlowType, CONST, InfoContainerContent } from 'app/consts';
 import { ApplicationState } from 'app/state';
 import {
   authenticateEmail,
-  AuthenticateEmailAction,
+  AuthenticateEmailActionCreator,
   createNotificationEmail,
-  CreateNotificationEmailAction,
+  CreateNotificationEmailActionCreator,
   subscribeWallet,
   unsubscribeWallet,
   UnsubscribeWalletActionCreator,
@@ -26,10 +26,10 @@ const i18n = require('../../../loc');
 interface Props {
   navigation: StackNavigationProp<RootStackParams, Route.ConfirmEmail>;
   route: RouteProp<RootStackParams, Route.ConfirmEmail>;
-  createNotificationEmail: (email: string, meta?: ActionMeta) => CreateNotificationEmailAction;
+  createNotificationEmail: CreateNotificationEmailActionCreator;
   subscribe: SubscribeWalletActionCreator;
   unsubscribe: UnsubscribeWalletActionCreator;
-  authenticate: (session_token: string, pin: string, meta: ActionMeta) => AuthenticateEmailAction;
+  authenticate: AuthenticateEmailActionCreator;
   sessionToken: string;
   notificationError: string;
   storedEmail: string;

--- a/src/screens/PinFlow/CreatePinScreen.tsx
+++ b/src/screens/PinFlow/CreatePinScreen.tsx
@@ -7,7 +7,7 @@ import { connect } from 'react-redux';
 import { Header, PinInput, ScreenTemplate } from 'app/components';
 import { Route, CONST, FlowType, RootStackParams } from 'app/consts';
 import { noop } from 'app/helpers/helpers';
-import { setUserVersion as setUserVersionAction, SetUserVersionActionFunction } from 'app/state/authentication/actions';
+import { setUserVersion as setUserVersionAction, SetUserVersionActionCreator } from 'app/state/authentication/actions';
 import { typography, palette } from 'app/styles';
 
 const i18n = require('../../../loc');
@@ -18,7 +18,7 @@ interface Props {
   appSettings: {
     isPinSet: boolean;
   };
-  setUserVersion: SetUserVersionActionFunction;
+  setUserVersion: SetUserVersionActionCreator;
 }
 
 interface State {

--- a/src/screens/WalletDetailsScreen.tsx
+++ b/src/screens/WalletDetailsScreen.tsx
@@ -42,10 +42,14 @@ interface Props {
 
 export class WalletDetailsScreen extends React.PureComponent<Props> {
   componentDidMount() {
+    this.checkSubscription();
+  }
+
+  checkSubscription = () => {
     const { wallet, email, checkSubscription } = this.props;
     if (!email || !wallet) return;
     checkSubscription([wallet], email);
-  }
+  };
 
   validationError = (value: string): string | undefined => {
     const trimmedValue = value.trim();
@@ -156,7 +160,10 @@ export class WalletDetailsScreen extends React.PureComponent<Props> {
             type: MessageType.success,
             buttonProps: {
               title: i18n.message.goToWalletDetails,
-              onPress: () => navigation.navigate(Route.WalletDetails, { id: wallet.id }),
+              onPress: () => {
+                navigation.navigate(Route.WalletDetails, { id: wallet.id });
+                this.checkSubscription();
+              },
             },
           });
         },

--- a/src/screens/WalletDetailsScreen.tsx
+++ b/src/screens/WalletDetailsScreen.tsx
@@ -47,8 +47,9 @@ export class WalletDetailsScreen extends React.PureComponent<Props> {
 
   checkSubscription = () => {
     const { wallet, email, checkSubscription } = this.props;
-    if (!email || !wallet) return;
-    checkSubscription([wallet], email);
+    if (email && wallet) {
+      checkSubscription([wallet], email);
+    }
   };
 
   validationError = (value: string): string | undefined => {

--- a/src/screens/WalletDetailsScreen.tsx
+++ b/src/screens/WalletDetailsScreen.tsx
@@ -148,7 +148,7 @@ export class WalletDetailsScreen extends React.PureComponent<Props> {
       navigation.navigate(Route.ConfirmEmail, {
         email,
         flowType,
-        walletsToSubscribe: [wallet],
+        wallets: [wallet],
         onSuccess: () => {
           CreateMessage({
             title: i18n.message.success,

--- a/src/state/authentication/actions.ts
+++ b/src/state/authentication/actions.ts
@@ -241,8 +241,8 @@ export const checkUserVersion = (): CheckUserVersionAction => ({
   type: AuthenticationAction.CheckUserVersion,
 });
 
-export type SetUserVersionActionFunction = (userVersion: USER_VERSIONS) => SetUserVersionAction;
-export const setUserVersion: SetUserVersionActionFunction = userVersion => ({
+export type SetUserVersionActionCreator = (userVersion: USER_VERSIONS) => SetUserVersionAction;
+export const setUserVersion: SetUserVersionActionCreator = userVersion => ({
   type: AuthenticationAction.SetUserVersion,
   payload: {
     userVersion,

--- a/src/state/notifications/actions.ts
+++ b/src/state/notifications/actions.ts
@@ -159,8 +159,8 @@ export type NotificationActionType =
   | CheckSubscriptionFailureAction
   | SetErrorAction;
 
-export type CreateNotificationEmailActionFunction = (email: string, meta?: ActionMeta) => CreateNotificationEmailAction;
-export const createNotificationEmail: CreateNotificationEmailActionFunction = (email, meta) => ({
+export type CreateNotificationEmailActionCreator = (email: string, meta?: ActionMeta) => CreateNotificationEmailAction;
+export const createNotificationEmail: CreateNotificationEmailActionCreator = (email, meta) => ({
   type: NotificationAction.CreateNotificationEmail,
   payload: { email },
   meta,
@@ -180,9 +180,9 @@ export const deleteNotificationEmail = (): DeleteNotificationEmailAction => ({
   type: NotificationAction.DeleteNotificationEmailAction,
 });
 
-export type VerifyNotificationEmailActionFunction = (email: string, meta?: ActionMeta) => VerifyNotificationEmailAction;
+export type VerifyNotificationEmailActionCreator = (email: string, meta?: ActionMeta) => VerifyNotificationEmailAction;
 
-export const verifyNotificationEmail: VerifyNotificationEmailActionFunction = (email, meta) => ({
+export const verifyNotificationEmail: VerifyNotificationEmailActionCreator = (email, meta) => ({
   type: NotificationAction.VerifyNotificationEmailAction,
   payload: { email },
   meta,
@@ -230,7 +230,12 @@ export const unsubscribeWalletFailure = (error: string): SubscribeWalletFailureA
   error,
 });
 
-export const authenticateEmail = (session_token: string, pin: string, meta?: ActionMeta): AuthenticateEmailAction => ({
+export type AuthenticateEmailActionCreator = (
+  session_token: string,
+  pin: string,
+  meta?: ActionMeta,
+) => AuthenticateEmailAction;
+export const authenticateEmail: AuthenticateEmailActionCreator = (session_token, pin, meta) => ({
   type: NotificationAction.AuthenticateEmailAction,
   payload: { session_token, pin },
   meta,
@@ -266,8 +271,8 @@ export const checkSubscriptionFailure = (error: string): CheckSubscriptionFailur
   error,
 });
 
-export type SetErrorActionFunction = (error: string) => SetErrorAction;
-export const setError: SetErrorActionFunction = error => ({
+export type SetErrorActionCreator = (error: string) => SetErrorAction;
+export const setError: SetErrorActionCreator = error => ({
   type: NotificationAction.SetErrorAction,
   error,
 });

--- a/src/state/notifications/actions.ts
+++ b/src/state/notifications/actions.ts
@@ -1,5 +1,5 @@
-import { SubscribePayload, UnsubscribePayload, AuthenticatePayload, SubscribeWalletSuccessPayload } from 'app/api';
-import { ActionMeta, WalletPayload, Wallet } from 'app/consts';
+import { AuthenticatePayload, SubscribeWalletSuccessPayload } from 'app/api';
+import { ActionMeta, Wallet } from 'app/consts';
 
 export enum NotificationAction {
   CreateNotificationEmail = 'CreateNotificationEmail',
@@ -73,7 +73,10 @@ export interface VerifyNotificationEmailActionSuccess {
 }
 export interface SubscribeWalletAction {
   type: NotificationAction.SubscribeWalletAction;
-  payload: SubscribePayload;
+  payload: {
+    wallets: Wallet[];
+    email: string;
+  };
 }
 
 export interface SubscribeWalletSuccessAction {
@@ -88,7 +91,10 @@ export interface SubscribeWalletFailureAction {
 
 export interface UnsubscribeWalletAction {
   type: NotificationAction.UnsubscribeWalletAction;
-  payload: UnsubscribePayload;
+  payload: {
+    wallets: Wallet[];
+    email: string;
+  };
 }
 
 export interface UnsubscribeWalletSuccessAction {
@@ -192,9 +198,10 @@ export const verifyNotificationEmailFailure = (error: string): VerifyNotificatio
   error,
 });
 
-export const subscribeWallet = (wallets: WalletPayload[], email: string, lang: string): SubscribeWalletAction => ({
+export type SubscribeWalletActionCreator = (wallets: Wallet[], email: string) => SubscribeWalletAction;
+export const subscribeWallet: SubscribeWalletActionCreator = (wallets, email) => ({
   type: NotificationAction.SubscribeWalletAction,
-  payload: { wallets, email, lang },
+  payload: { wallets, email },
 });
 
 export const subscribeWalletSuccess = (sessionToken: string): SubscribeWalletSuccessAction => ({
@@ -207,9 +214,10 @@ export const subscribeWalletFailure = (error: string): SubscribeWalletFailureAct
   error,
 });
 
-export const unsubscribeWallet = (hashes: string[], email: string): UnsubscribeWalletAction => ({
+export type UnsubscribeWalletActionCreator = (wallets: Wallet[], email: string) => UnsubscribeWalletAction;
+export const unsubscribeWallet: UnsubscribeWalletActionCreator = (wallets, email) => ({
   type: NotificationAction.UnsubscribeWalletAction,
-  payload: { hashes, email },
+  payload: { wallets, email },
 });
 
 export const unsubscribeWalletSuccess = (sessionToken: string): SubscribeWalletSuccessAction => ({

--- a/src/state/notifications/reducer.ts
+++ b/src/state/notifications/reducer.ts
@@ -12,6 +12,7 @@ export interface NotificationState {
   isLoading: boolean;
   sessionToken: string;
   subscribedIds: string[];
+  failedTries: number;
 }
 
 const initialState: NotificationState = {
@@ -22,6 +23,7 @@ const initialState: NotificationState = {
   isLoading: false,
   sessionToken: '',
   subscribedIds: [],
+  failedTries: 0,
 };
 
 const reducer = (state = initialState, action: NotificationActionType): NotificationState => {
@@ -35,15 +37,27 @@ const reducer = (state = initialState, action: NotificationActionType): Notifica
         isLoading: false,
         pin: '',
       };
+    case NotificationAction.UnsubscribeWalletAction:
+    case NotificationAction.SubscribeWalletAction:
+      return {
+        ...state,
+        failedTries: 0,
+      };
     case NotificationAction.SubscribeWalletFailureAction:
     case NotificationAction.UnsubscribeWalletFailureAction:
-    case NotificationAction.AuthenticateEmailFailureAction:
     case NotificationAction.CheckSubscriptionFailureAction:
     case NotificationAction.CreateNotificationEmailFailure:
     case NotificationAction.VerifyNotificationEmailActionFailure:
       return {
         ...state,
         error: action.error,
+        isLoading: false,
+      };
+    case NotificationAction.AuthenticateEmailFailureAction:
+      return {
+        ...state,
+        error: action.error,
+        failedTries: state.failedTries + 1,
         isLoading: false,
       };
     case NotificationAction.DeleteNotificationEmailAction:
@@ -69,7 +83,6 @@ const reducer = (state = initialState, action: NotificationActionType): Notifica
     case NotificationAction.UnsubscribeWalletSuccessAction:
       return {
         ...state,
-        error: '',
         sessionToken: action.payload.sessionToken,
       };
     case NotificationAction.AuthenticateEmailSuccessAction:
@@ -77,6 +90,7 @@ const reducer = (state = initialState, action: NotificationActionType): Notifica
         ...state,
         error: '',
         sessionToken: '',
+        failedTries: 0,
       };
     case NotificationAction.SetErrorAction:
       return {

--- a/src/state/notifications/selectors.ts
+++ b/src/state/notifications/selectors.ts
@@ -1,5 +1,6 @@
 import { createSelector } from 'reselect';
 
+import { CONST } from 'app/consts';
 import { ApplicationState } from 'app/state';
 import { WalletsState } from 'app/state/wallets/reducer';
 import { getById } from 'app/state/wallets/selectors';
@@ -18,12 +19,19 @@ export const sessionToken = createSelector(local, state => state.sessionToken);
 export const notificationError = createSelector(local, state => state.error);
 export const storedEmail = createSelector(local, state => state.email);
 export const storedPin = createSelector(local, state => state.pin);
-export const readableError = createSelector(notificationError, err => {
+export const failedTries = createSelector(local, state => state.failedTries);
+
+export const readableError = createSelector(notificationError, failedTries, (err, failNo) => {
   if (err.startsWith(messages.requestFailed5XX)) {
     return i18n.connectionIssue.couldntConnectToServer;
   }
   if (err === messages.invalidEmail) {
     return i18n.notifications.invalidAddressError;
+  }
+
+  if (err === messages.wrongPIN && failNo < CONST.emailCodeErrorMax) {
+    return i18n.formatString(i18n.notifications.codeError, { attemptsLeft: CONST.emailCodeErrorMax - failNo });
+    // return i18n.formatString(i18n.notifications.codeFinalError, { attemptsLeft: CONST.emailCodeErrorMax });
   }
   return err;
 });

--- a/src/state/notifications/selectors.ts
+++ b/src/state/notifications/selectors.ts
@@ -31,7 +31,6 @@ export const readableError = createSelector(notificationError, failedTries, (err
 
   if (err === messages.wrongPIN && failNo < CONST.emailCodeErrorMax) {
     return i18n.formatString(i18n.notifications.codeError, { attemptsLeft: CONST.emailCodeErrorMax - failNo });
-    // return i18n.formatString(i18n.notifications.codeFinalError, { attemptsLeft: CONST.emailCodeErrorMax });
   }
   return err;
 });

--- a/src/state/wallets/selectors.ts
+++ b/src/state/wallets/selectors.ts
@@ -76,10 +76,6 @@ export const walletsWithRecoveryTransaction = createSelector(wallets, walletsLis
   walletsList.filter(wallet => [HDSegwitP2SHArWallet.type, HDSegwitP2SHAirWallet.type].includes(wallet.type)),
 );
 
-export const subscribableWallets = createSelector(wallets, walletsList =>
-  walletsList.filter(wallet => wallet.type === HDSegwitP2SHAirWallet.type),
-); // TODO - remove when backend is ready to subscribe other wallet types
-
 export const allWallet = createSelector(wallets, walletsList => {
   const { incoming_balance, balance } = walletsList.reduce(
     (acc, wallet) => ({


### PR DESCRIPTION
## What does this PR do?

* Add resend and error handling for code confirm screen
* Fix wallets details subscription refresh after sub/unsub

#### *Any scout cleaning/refactoring?*

* moved failed tries and the error to redux to make it possible to manage the state and get rid of two sources of truth.
* move whole sub/unsub logic to sagas

- [ ] Checked on iOS
- [X] Checked on Android

