### PR TITLE
Fix notification import wallet flow

### DIFF
--- a/src/screens/ImportWalletScreen.tsx
+++ b/src/screens/ImportWalletScreen.tsx
@@ -172,7 +172,7 @@ export class ImportWalletScreen extends Component<Props, State> {
           wallets: [wallet],
           onSuccess: this.showSuccessImportMessageScreen,
         }),
-      onBack: () => this.props.navigation.navigate(Route.MainTabStackNavigator, { screen: Route.Dashboard }),
+      onBack: () => this.showSuccessImportMessageScreen(),
       isBackArrow: false,
     });
   };
@@ -199,16 +199,20 @@ export class ImportWalletScreen extends Component<Props, State> {
       });
     }
     newWallet.setLabel(this.state.label);
+
     if (email) {
-      return checkSubscription([newWallet], email, {
-        onSuccess: (ids: string[]) => {
-          const isWalletSubscribed = ids.some(id => id === newWallet.id);
-          this.importWallet(newWallet, () => {
+      return this.importWallet(newWallet, () => {
+        checkSubscription([newWallet], email, {
+          onSuccess: (ids: string[]) => {
+            const isWalletSubscribed = ids.some(id => id === newWallet.id);
             isWalletSubscribed
               ? this.showSuccessImportMessageScreen()
               : this.navigateToConfirmEmailSubscription(newWallet);
-          });
-        },
+          },
+          onFailure: () => {
+            this.showSuccessImportMessageScreen();
+          },
+        });
       });
     }
     this.importWallet(newWallet, () => {

--- a/src/screens/ImportWalletScreen.tsx
+++ b/src/screens/ImportWalletScreen.tsx
@@ -200,9 +200,9 @@ export class ImportWalletScreen extends Component<Props, State> {
     }
     newWallet.setLabel(this.state.label);
 
-    if (email) {
-      return this.importWallet(newWallet, () => {
-        checkSubscription([newWallet], email, {
+    this.importWallet(newWallet, () => {
+      if (email) {
+        return checkSubscription([newWallet], email, {
           onSuccess: (ids: string[]) => {
             const isWalletSubscribed = ids.some(id => id === newWallet.id);
             isWalletSubscribed
@@ -213,9 +213,7 @@ export class ImportWalletScreen extends Component<Props, State> {
             this.showSuccessImportMessageScreen();
           },
         });
-      });
-    }
-    this.importWallet(newWallet, () => {
+      }
       this.showSuccessImportMessageScreen();
     });
   };


### PR DESCRIPTION
## What does this PR do?

Change the notification import wallet flow so the check subscription occurs after importing the wallet

- [ ] Checked on iOS
- [X] Checked on Android