### PR TITLE
Decrypt storage at the app start

### DIFF
--- a/src/navigators/Navigator.tsx
+++ b/src/navigators/Navigator.tsx
@@ -9,6 +9,7 @@ import config from 'app/config';
 import { CONST, USER_VERSIONS } from 'app/consts';
 import { Toasts } from 'app/containers';
 import { RenderMessage, MessageType } from 'app/helpers/MessageCreator';
+import { BlueApp } from 'app/legacy';
 import { RootNavigator } from 'app/navigators';
 import { UnlockScreen, TermsConditionsScreen, ConnectionIssuesScreen } from 'app/screens';
 import { BetaVersionScreen } from 'app/screens/BetaVersionScreen';
@@ -79,8 +80,10 @@ class Navigator extends React.Component<Props, State> {
     isChamberOfSecretsClosed: false,
   };
 
-  componentDidMount() {
+  async componentDidMount() {
     const { checkCredentials, startElectrumXListeners, checkTc, checkConnection, checkUserVersion } = this.props;
+    await BlueApp.startAndDecrypt();
+
     checkUserVersion();
     checkTc();
     checkCredentials();
@@ -129,6 +132,15 @@ class Navigator extends React.Component<Props, State> {
     return !isAuthenticated && isTxPasswordSet && isPinSet;
   };
 
+  shouldRenderConnectionIssues = () => {
+    const { hasConnectedToServerAtLeaseOnce } = this.props;
+
+    if (this.shouldRenderUnlockScreen()) {
+      return false;
+    }
+    return !hasConnectedToServerAtLeaseOnce && !this.shouldRenderCredentialsCreation();
+  };
+
   preventOpenAppWithRootedPhone = () => {
     if (isIos()) {
       return RenderMessage({
@@ -154,14 +166,7 @@ class Navigator extends React.Component<Props, State> {
   };
 
   renderRoutes = () => {
-    const {
-      isLoading,
-      unlockKey,
-      isAuthenticated,
-      hasConnectedToServerAtLeaseOnce,
-      isTcAccepted,
-      userVersion,
-    } = this.props;
+    const { isLoading, unlockKey, isAuthenticated, isTcAccepted, userVersion } = this.props;
 
     if (isLoading) {
       return null;
@@ -183,20 +188,15 @@ class Navigator extends React.Component<Props, State> {
       return <BetaVersionScreen onButtonPress={this.handleAcceptBetaVersionRisk} />;
     }
 
-    const _shouldRenderCredentialsCreation = this.shouldRenderCredentialsCreation();
-
-    if (!hasConnectedToServerAtLeaseOnce && !_shouldRenderCredentialsCreation) {
-      return <ConnectionIssuesScreen />;
-    }
-
     return (
       <>
         <RootNavigator
-          shouldRenderCredentialsCreation={_shouldRenderCredentialsCreation}
+          shouldRenderCredentialsCreation={this.shouldRenderCredentialsCreation()}
           shouldRenderNotification={this.shouldRenderNotification()}
           userVersion={userVersion}
         />
         {isAuthenticated && <Toasts />}
+        {this.shouldRenderConnectionIssues() && <ConnectionIssuesScreen />}
         {this.shouldRenderUnlockScreen() && <UnlockScreen key={unlockKey} />}
       </>
     );

--- a/src/screens/ConnectionIssues/ConnectionIssuesScreen.tsx
+++ b/src/screens/ConnectionIssues/ConnectionIssuesScreen.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Text, StyleSheet, View } from 'react-native';
 import { useSelector } from 'react-redux';
 
-import { ScreenTemplate, Loader } from 'app/components';
+import { Loader } from 'app/components';
 import { selectors } from 'app/state/electrumX';
 import { typography, palette } from 'app/styles';
 
@@ -31,20 +31,27 @@ export const ConnectionIssuesScreen = () => {
   };
 
   return (
-    <ScreenTemplate>
-      <View style={styles.container}>
-        <Text style={styles.title}>{getTitle()}</Text>
-        <Loader size={137} />
-        <Text style={styles.description}>{getDescription()}</Text>
-      </View>
-    </ScreenTemplate>
+    // <ScreenTemplate>
+    <View style={styles.container}>
+      <Text style={styles.title}>{getTitle()}</Text>
+      <Loader size={137} />
+      <Text style={styles.description}>{getDescription()}</Text>
+    </View>
+    // </ScreenTemplate>
   );
 };
 
 export default ConnectionIssuesScreen;
 
 const styles = StyleSheet.create({
-  container: { justifyContent: 'center', alignItems: 'center', flex: 1 },
+  container: {
+    backgroundColor: palette.white,
+    alignItems: 'center',
+    ...StyleSheet.absoluteFillObject,
+    justifyContent: 'center',
+    flex: 1,
+    zIndex: 1000,
+  },
   title: { ...typography.headline4, textAlign: 'center', paddingBottom: 66 },
   description: {
     ...typography.body,

--- a/src/state/authentication/sagas.ts
+++ b/src/state/authentication/sagas.ts
@@ -1,7 +1,6 @@
 import { takeLatest, takeEvery, put, call } from 'redux-saga/effects';
 
 import { CONST } from 'app/consts';
-import { BlueApp } from 'app/legacy';
 import { SecureStorageService, StoreService } from 'app/services';
 
 import {
@@ -28,7 +27,6 @@ export function* checkCredentialsSaga(action: CheckCredentialsAction | unknown) 
   const { meta } = action as CheckCredentialsAction;
 
   try {
-    yield BlueApp.startAndDecrypt();
     const pin = yield call(SecureStorageService.getSecuredValue, CONST.pin);
     const transactionPassword = yield call(SecureStorageService.getSecuredValue, CONST.transactionPassword);
     const credentials = {


### PR DESCRIPTION
## What does this PR do?

* decrypt storage before all init action so there is no possibility that the app blinks with empty wallets view, because of not loading them from disk
* moved connection issues screen as RootNavigator children so there is no possibility that it would reset the navigator state


- [ ] Checked on iOS
- [X] Checked on Android
