### PR TITLE
Confirm email refactor

### DIFF
--- a/src/consts/models.tsx
+++ b/src/consts/models.tsx
@@ -533,6 +533,7 @@ export type RootStackParams = {
     flowType: ConfirmAddressFlowType;
     onBack?: () => void;
     onSuccess: (arg?: any) => void;
+    onResend: () => void;
   };
   [Route.UpdateEmailNotification]: {
     subscribedWallets: Wallet[];

--- a/src/screens/CreateWalletScreen.tsx
+++ b/src/screens/CreateWalletScreen.tsx
@@ -17,7 +17,11 @@ import {
 } from 'app/legacy';
 import { ApplicationState } from 'app/state';
 import { AppSettingsState } from 'app/state/appSettings/reducer';
-import { storedEmail } from 'app/state/notifications/selectors';
+import {
+  subscribeWallet as subscribeWalletAction,
+  SubscribeWalletActionCreator,
+} from 'app/state/notifications/actions';
+import { storedEmail, readableError } from 'app/state/notifications/selectors';
 import { selectors as walletsSelector } from 'app/state/wallets';
 import { createWallet as createWalletAction, CreateWalletAction } from 'app/state/wallets/actions';
 import { palette, typography } from 'app/styles';
@@ -29,8 +33,10 @@ interface Props {
   route: RouteProp<RootStackParams, Route.CreateWallet>;
   appSettings: AppSettingsState;
   createWallet: (wallet: Wallet, meta?: ActionMeta) => CreateWalletAction;
+  subscribe: SubscribeWalletActionCreator;
   walletsLabels: string[];
   email: string;
+  error: string;
 }
 
 interface State {
@@ -102,6 +108,10 @@ export class CreateWalletScreen extends React.PureComponent<Props, State> {
     });
   };
 
+  onFailure = () => {
+    Alert.alert(this.props.error);
+  };
+
   navigateToConfirmEmailSubscription = (wallet: Wallet) => {
     const { navigation, email } = this.props;
 
@@ -110,12 +120,18 @@ export class CreateWalletScreen extends React.PureComponent<Props, State> {
       children: this.renderConfirmScreenContent(),
       gestureEnabled: false,
       onConfirm: () =>
-        navigation.navigate(Route.ConfirmEmail, {
-          email,
-          flowType: ConfirmAddressFlowType.SUBSCRIBE,
-          wallets: [wallet],
-          onSuccess: this.navigateToSuccesfullNotificationSubscriptionMessage,
+        this.props.subscribe([wallet], email, {
+          onSuccess: () =>
+            navigation.navigate(Route.ConfirmEmail, {
+              email,
+              flowType: ConfirmAddressFlowType.SUBSCRIBE,
+              wallets: [wallet],
+              onSuccess: this.navigateToSuccesfullNotificationSubscriptionMessage,
+              onResend: () => this.props.subscribe([wallet], email, { onFailure: this.onFailure }),
+            }),
+          onFailure: this.onFailure,
         }),
+
       onBack: () => this.props.navigation.navigate(Route.MainTabStackNavigator, { screen: Route.Dashboard }),
       isBackArrow: false,
     });
@@ -383,10 +399,12 @@ const mapStateToProps = (state: ApplicationState) => ({
   appSettings: state.appSettings,
   walletsLabels: walletsSelector.getWalletsLabels(state),
   email: storedEmail(state),
+  error: readableError(state),
 });
 
 const mapDispatchToProps = {
   createWallet: createWalletAction,
+  subscribe: subscribeWalletAction,
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(CreateWalletScreen);

--- a/src/screens/CreateWalletScreen.tsx
+++ b/src/screens/CreateWalletScreen.tsx
@@ -108,10 +108,6 @@ export class CreateWalletScreen extends React.PureComponent<Props, State> {
     });
   };
 
-  onFailure = () => {
-    Alert.alert(this.props.error);
-  };
-
   navigateToConfirmEmailSubscription = (wallet: Wallet) => {
     const { navigation, email } = this.props;
 
@@ -119,19 +115,16 @@ export class CreateWalletScreen extends React.PureComponent<Props, State> {
       title: i18n.notifications.notifications,
       children: this.renderConfirmScreenContent(),
       gestureEnabled: false,
-      onConfirm: () =>
-        this.props.subscribe([wallet], email, {
-          onSuccess: () =>
-            navigation.navigate(Route.ConfirmEmail, {
-              email,
-              flowType: ConfirmAddressFlowType.SUBSCRIBE,
-              wallets: [wallet],
-              onSuccess: this.navigateToSuccesfullNotificationSubscriptionMessage,
-              onResend: () => this.props.subscribe([wallet], email, { onFailure: this.onFailure }),
-            }),
-          onFailure: this.onFailure,
-        }),
-
+      onConfirm: () => {
+        this.props.subscribe([wallet], email);
+        navigation.navigate(Route.ConfirmEmail, {
+          email,
+          flowType: ConfirmAddressFlowType.SUBSCRIBE,
+          wallets: [wallet],
+          onSuccess: this.navigateToSuccesfullNotificationSubscriptionMessage,
+          onResend: () => this.props.subscribe([wallet], email),
+        });
+      },
       onBack: () => this.props.navigation.navigate(Route.MainTabStackNavigator, { screen: Route.Dashboard }),
       isBackArrow: false,
     });

--- a/src/screens/ImportWalletScreen.tsx
+++ b/src/screens/ImportWalletScreen.tsx
@@ -168,10 +168,6 @@ export class ImportWalletScreen extends Component<Props, State> {
     </>
   );
 
-  onFailure = () => {
-    Alert.alert(this.props.error);
-  };
-
   navigateToConfirmEmailSubscription = (wallet: Wallet) => {
     const { navigation, email } = this.props;
 
@@ -179,18 +175,16 @@ export class ImportWalletScreen extends Component<Props, State> {
       title: i18n.notifications.notifications,
       children: this.renderConfirmScreenContent(),
       gestureEnabled: false,
-      onConfirm: () =>
-        this.props.subscribe([wallet], email, {
-          onSuccess: () =>
-            navigation.navigate(Route.ConfirmEmail, {
-              email,
-              flowType: ConfirmAddressFlowType.SUBSCRIBE,
-              wallets: [wallet],
-              onSuccess: this.showSuccessImportMessageScreen,
-              onResend: () => this.props.subscribe([wallet], email, { onFailure: this.onFailure }),
-            }),
-          onFailure: this.onFailure,
-        }),
+      onConfirm: () => {
+        this.props.subscribe([wallet], email);
+        navigation.navigate(Route.ConfirmEmail, {
+          email,
+          flowType: ConfirmAddressFlowType.SUBSCRIBE,
+          wallets: [wallet],
+          onSuccess: this.showSuccessImportMessageScreen,
+          onResend: () => this.props.subscribe([wallet], email),
+        });
+      },
 
       onBack: () => this.showSuccessImportMessageScreen(),
       isBackArrow: false,

--- a/src/screens/Notifications/AddNotificationEmailScreen.tsx
+++ b/src/screens/Notifications/AddNotificationEmailScreen.tsx
@@ -1,7 +1,7 @@
 import { RouteProp } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import React, { PureComponent } from 'react';
-import { Text, StyleSheet, View } from 'react-native';
+import { Text, StyleSheet, View, Alert } from 'react-native';
 import { connect } from 'react-redux';
 
 import { Header, InputItem, ScreenTemplate, Button, FlatButton } from 'app/components';
@@ -56,6 +56,8 @@ class AddNotificationEmailScreen extends PureComponent<Props, State> {
     });
   };
 
+  onFailure = () => Alert.alert(this.props.error);
+
   goToLocalEmailConfirm = () => {
     const { verifyNotificationEmail, navigation, createNotificationEmail, route } = this.props;
 
@@ -81,6 +83,7 @@ class AddNotificationEmailScreen extends PureComponent<Props, State> {
           },
           email,
         }),
+      onFailure: this.onFailure,
     });
   };
 
@@ -109,7 +112,7 @@ class AddNotificationEmailScreen extends PureComponent<Props, State> {
           email,
           onSuccess,
           wallets: walletsToSubscribe,
-          onSkip: () => this.goToLocalEmailConfirm(),
+          onSkip: this.goToLocalEmailConfirm,
         });
       },
     });
@@ -151,6 +154,7 @@ class AddNotificationEmailScreen extends PureComponent<Props, State> {
                 testID="skip-notification-email"
                 containerStyle={styles.skipButton}
                 title={i18n._.skip}
+                loading={isLoading}
                 onPress={this.skipAddEmail}
               />
             )}

--- a/src/screens/Notifications/AddNotificationEmailScreen.tsx
+++ b/src/screens/Notifications/AddNotificationEmailScreen.tsx
@@ -1,7 +1,7 @@
 import { RouteProp } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import React, { PureComponent } from 'react';
-import { Text, StyleSheet, View, Alert } from 'react-native';
+import { Text, StyleSheet, View } from 'react-native';
 import { connect } from 'react-redux';
 
 import { Header, InputItem, ScreenTemplate, Button, FlatButton } from 'app/components';
@@ -56,8 +56,6 @@ class AddNotificationEmailScreen extends PureComponent<Props, State> {
     });
   };
 
-  onFailure = () => Alert.alert(this.props.error);
-
   goToLocalEmailConfirm = () => {
     const { verifyNotificationEmail, navigation, createNotificationEmail, route } = this.props;
 
@@ -65,25 +63,22 @@ class AddNotificationEmailScreen extends PureComponent<Props, State> {
 
     const { email } = this.state;
 
-    verifyNotificationEmail(email, {
-      onSuccess: () =>
-        navigation.navigate(Route.LocalConfirmNotificationCode, {
-          children: (
-            <View style={styles.infoContainer}>
-              <Text style={typography.headline4}>{i18n.notifications.confirmEmail}</Text>
-              <Text style={styles.codeDescription}>{i18n.notifications.pleaseEnter}</Text>
-              <Text style={typography.headline5}>{email}</Text>
-            </View>
-          ),
-          title,
-          onSuccess: () => {
-            createNotificationEmail(email, {
-              onSuccess,
-            });
-          },
-          email,
-        }),
-      onFailure: this.onFailure,
+    verifyNotificationEmail(email);
+    navigation.navigate(Route.LocalConfirmNotificationCode, {
+      children: (
+        <View style={styles.infoContainer}>
+          <Text style={typography.headline4}>{i18n.notifications.confirmEmail}</Text>
+          <Text style={styles.codeDescription}>{i18n.notifications.pleaseEnter}</Text>
+          <Text style={typography.headline5}>{email}</Text>
+        </View>
+      ),
+      title,
+      onSuccess: () => {
+        createNotificationEmail(email, {
+          onSuccess,
+        });
+      },
+      email,
     });
   };
 

--- a/src/screens/Notifications/ChooseWalletsForNotificationScreen.tsx
+++ b/src/screens/Notifications/ChooseWalletsForNotificationScreen.tsx
@@ -1,7 +1,7 @@
 import { RouteProp } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import React, { PureComponent } from 'react';
-import { View, Text, StyleSheet, FlatList, Alert } from 'react-native';
+import { View, Text, StyleSheet, FlatList } from 'react-native';
 import { connect } from 'react-redux';
 
 import { Header, ScreenTemplate, Button, FlatButton, CheckBox } from 'app/components';
@@ -77,20 +77,16 @@ export class ChooseWalletsForNotificationScreen extends PureComponent<Props, Sta
     </View>
   );
 
-  onFailure = () => {
-    Alert.alert(this.props.error);
-  };
-
   onResend = () => {
     const {
       route: { params },
     } = this.props;
 
     if (params.flowType === ConfirmAddressFlowType.SUBSCRIBE) {
-      return this.props.subscribe(this.state.wallets, params.email, { onFailure: this.onFailure });
+      return this.props.subscribe(this.state.wallets, params.email);
     }
     if (params.flowType === ConfirmAddressFlowType.UNSUBSCRIBE) {
-      return this.props.unsubscribe(this.state.wallets, params.email, { onFailure: this.onFailure });
+      return this.props.unsubscribe(this.state.wallets, params.email);
     }
   };
 
@@ -101,27 +97,21 @@ export class ChooseWalletsForNotificationScreen extends PureComponent<Props, Sta
     } = this.props;
 
     if (params.flowType === ConfirmAddressFlowType.SUBSCRIBE) {
-      return this.props.subscribe(this.state.wallets, params.email, {
-        onSuccess: () =>
-          navigation.navigate(Route.ConfirmEmail, {
-            email: params.email,
-            flowType: params.flowType,
-            onSuccess: params.onSuccess,
-            onResend: this.onResend,
-          }),
-        onFailure: this.onFailure,
+      this.props.subscribe(this.state.wallets, params.email);
+      return navigation.navigate(Route.ConfirmEmail, {
+        email: params.email,
+        flowType: params.flowType,
+        onSuccess: params.onSuccess,
+        onResend: this.onResend,
       });
     }
     if (params.flowType === ConfirmAddressFlowType.UNSUBSCRIBE) {
-      return this.props.unsubscribe(this.state.wallets, params.email, {
-        onSuccess: () =>
-          navigation.navigate(Route.ConfirmEmail, {
-            email: params.email,
-            flowType: params.flowType,
-            onSuccess: params.onSuccess,
-            onResend: this.onResend,
-          }),
-        onFailure: this.onFailure,
+      this.props.unsubscribe(this.state.wallets, params.email);
+      navigation.navigate(Route.ConfirmEmail, {
+        email: params.email,
+        flowType: params.flowType,
+        onSuccess: params.onSuccess,
+        onResend: this.onResend,
       });
     }
   };
@@ -143,6 +133,8 @@ export class ChooseWalletsForNotificationScreen extends PureComponent<Props, Sta
             <FlatButton containerStyle={styles.skipButton} title={i18n._.skip} onPress={onSkip} loading={isLoading} />
           </>
         }
+        noScroll
+        contentContainer={styles.screenTemplate}
       >
         <View style={styles.infoContainer}>
           <Text style={typography.headline4}>{subtitle}</Text>
@@ -153,9 +145,9 @@ export class ChooseWalletsForNotificationScreen extends PureComponent<Props, Sta
         </View>
 
         <FlatList
-          data={wallets}
+          data={[...wallets, ...wallets, ...wallets, ...wallets, ...wallets]}
           renderItem={item => this.renderItem(item.item)}
-          keyExtractor={item => item.id}
+          keyExtractor={(_, index) => index.toString()}
           ListHeaderComponent={this.renderListHeader()}
         />
       </ScreenTemplate>
@@ -179,6 +171,7 @@ const styles = StyleSheet.create({
   infoContainer: {
     alignItems: 'center',
   },
+  screenTemplate: { flex: 1 },
   infoDescription: {
     ...typography.caption,
     color: palette.textGrey,

--- a/src/screens/Notifications/ConfirmEmailScreen.tsx
+++ b/src/screens/Notifications/ConfirmEmailScreen.tsx
@@ -49,7 +49,6 @@ class ConfirmEmailScreen extends Component<Props, State> {
   };
 
   componentDidMount() {
-    this.infoContainerContent.onInit?.();
     this.props.setError('');
   }
 
@@ -73,16 +72,13 @@ class ConfirmEmailScreen extends Component<Props, State> {
       createNotificationEmail,
       storedEmail,
       route: {
-        params: { email, wallets, onSuccess },
+        params: { email, onSuccess },
       },
     } = this.props;
 
     return {
       title: i18n.notifications.verifyAction,
       description: i18n.notifications.verifyActionDescription,
-      onInit: () => {
-        wallets && this.props.subscribe(wallets, email);
-      },
       onCodeConfirm: () => {
         if (storedEmail) {
           return onSuccess();
@@ -95,19 +91,14 @@ class ConfirmEmailScreen extends Component<Props, State> {
   unsubscribeFlowContent = () => {
     const {
       route: {
-        params: { email, wallets, onSuccess },
+        params: { onSuccess },
       },
     } = this.props;
 
     return {
       title: i18n.notifications.verifyAction,
       description: i18n.notifications.verifyActionDescription,
-      onInit: () => {
-        wallets && this.props.unsubscribe(wallets, email);
-      },
-      onCodeConfirm: () => {
-        onSuccess();
-      },
+      onCodeConfirm: onSuccess,
     };
   };
 
@@ -140,11 +131,11 @@ class ConfirmEmailScreen extends Component<Props, State> {
   };
 
   onError = () => {
-    const { failedTries, setError } = this.props;
+    const { failedTries, setError, route } = this.props;
 
     this.setCode('');
     if (failedTries === CONST.emailCodeErrorMax) {
-      this.infoContainerContent?.onInit?.();
+      route.params.onResend();
       setError(i18n.formatString(i18n.notifications.codeFinalError, { attemptsNo: CONST.emailCodeErrorMax }));
     }
   };
@@ -171,11 +162,11 @@ class ConfirmEmailScreen extends Component<Props, State> {
   };
 
   onResend = () => {
-    const { setError } = this.props;
+    const { setError, route } = this.props;
 
     this.setCode('');
     setError('');
-    this.infoContainerContent.onInit?.();
+    route.params.onResend();
   };
 
   render() {

--- a/src/screens/Notifications/NotificationScreen.tsx
+++ b/src/screens/Notifications/NotificationScreen.tsx
@@ -117,6 +117,7 @@ export class NotificationScreen extends Component<Props> {
           buttonProps: {
             title: i18n.notifications.goToNotifications,
             onPress: () => {
+              this.props.checkSubscription(this.props.wallets, this.props.email);
               this.navigateBackToScreen();
             },
           },

--- a/src/screens/Notifications/UpdateEmailNotificationScreen.tsx
+++ b/src/screens/Notifications/UpdateEmailNotificationScreen.tsx
@@ -1,7 +1,7 @@
 import { RouteProp } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import React, { PureComponent } from 'react';
-import { Text, StyleSheet, View, Alert } from 'react-native';
+import { Text, StyleSheet, View } from 'react-native';
 import { connect } from 'react-redux';
 
 import { Header, InputItem, ScreenTemplate, Button } from 'app/components';
@@ -66,25 +66,20 @@ class UpdateEmailNotificationScreen extends PureComponent<Props, State> {
 
     const { email } = this.state;
 
-    verifyNotificationEmail(email, {
-      onSuccess: () =>
-        navigation.navigate(Route.LocalConfirmNotificationCode, {
-          children: (
-            <View style={styles.infoContainer}>
-              <Text style={typography.headline4}>{i18n.notifications.confirmEmail}</Text>
-              <Text style={styles.codeDescription}>{i18n.notifications.pleaseEnter}</Text>
-              <Text style={typography.headline5}>{email}</Text>
-            </View>
-          ),
-          title: i18n.notifications.notifications,
-          onSuccess: this.onUpdateSuccess,
-          email,
-        }),
-      onFailure: this.onFailure,
+    verifyNotificationEmail(email);
+    navigation.navigate(Route.LocalConfirmNotificationCode, {
+      children: (
+        <View style={styles.infoContainer}>
+          <Text style={typography.headline4}>{i18n.notifications.confirmEmail}</Text>
+          <Text style={styles.codeDescription}>{i18n.notifications.pleaseEnter}</Text>
+          <Text style={typography.headline5}>{email}</Text>
+        </View>
+      ),
+      title: i18n.notifications.notifications,
+      onSuccess: this.onUpdateSuccess,
+      email,
     });
   };
-
-  onFailure = () => Alert.alert(this.props.error);
 
   onUpdateSuccess = () =>
     this.props.createNotificationEmail(this.state.email, {
@@ -140,7 +135,7 @@ class UpdateEmailNotificationScreen extends PureComponent<Props, State> {
 
   onConfirm = () => {
     const { email } = this.state;
-    const { navigation, route, setError, storedEmail, updateNotificationEmail } = this.props;
+    const { route, setError, storedEmail, updateNotificationEmail } = this.props;
     const { subscribedWallets } = route.params;
 
     if (!isEmail(email)) {

--- a/src/screens/WalletDetailsScreen.tsx
+++ b/src/screens/WalletDetailsScreen.tsx
@@ -2,7 +2,7 @@ import { RouteProp } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { cloneDeep } from 'lodash';
 import React from 'react';
-import { Alert, StyleSheet, View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import { connect } from 'react-redux';
 
 import { Button, FlatButton, Header, ScreenTemplate, WalletCard, ButtonType, Text } from 'app/components';
@@ -198,28 +198,17 @@ export class WalletDetailsScreen extends React.PureComponent<Props> {
     wallet && navigation.navigate(Route.WalletDetails, { id: wallet.id });
   };
 
-  onFailure = () => {
-    Alert.alert(this.props.error);
-  };
-
   subscribe = (wallet: Wallet, email: string) => {
-    this.props.subscribe([wallet], email, {
-      onSuccess: () =>
-        this.confirmEmail(ConfirmAddressFlowType.SUBSCRIBE, () =>
-          this.props.subscribe([wallet], email, { onFailure: this.onFailure }),
-        ),
-      onFailure: this.onFailure,
-    });
+    this.props.subscribe([wallet], email);
+    this.confirmEmail(ConfirmAddressFlowType.SUBSCRIBE, () => this.props.subscribe([wallet], email));
+    // , {
+    // onSuccess: () => this.confirmEmail(ConfirmAddressFlowType.SUBSCRIBE, () => this.props.subscribe([wallet], email)),
+    // });
   };
 
   unSubscribe = (wallet: Wallet, email: string) => {
-    this.props.unsubscribe([wallet], email, {
-      onSuccess: () =>
-        this.confirmEmail(ConfirmAddressFlowType.UNSUBSCRIBE, () =>
-          this.props.unsubscribe([wallet], email, { onFailure: this.onFailure }),
-        ),
-      onFailure: this.onFailure,
-    });
+    this.props.unsubscribe([wallet], email);
+    this.confirmEmail(ConfirmAddressFlowType.UNSUBSCRIBE, () => this.props.unsubscribe([wallet], email));
   };
 
   onSubscribeButtonPress = () => {

--- a/src/state/notifications/actions.ts
+++ b/src/state/notifications/actions.ts
@@ -89,6 +89,7 @@ export interface SubscribeWalletAction {
     wallets: Wallet[];
     email: string;
   };
+  meta?: ActionMeta;
 }
 
 export interface SubscribeWalletSuccessAction {
@@ -107,6 +108,7 @@ export interface UnsubscribeWalletAction {
     wallets: Wallet[];
     email: string;
   };
+  meta?: ActionMeta;
 }
 
 export interface UnsubscribeWalletSuccessAction {
@@ -229,10 +231,15 @@ export const verifyNotificationEmailFailure = (error: string): VerifyNotificatio
   error,
 });
 
-export type SubscribeWalletActionCreator = (wallets: Wallet[], email: string) => SubscribeWalletAction;
-export const subscribeWallet: SubscribeWalletActionCreator = (wallets, email) => ({
+export type SubscribeWalletActionCreator = (
+  wallets: Wallet[],
+  email: string,
+  meta?: ActionMeta,
+) => SubscribeWalletAction;
+export const subscribeWallet: SubscribeWalletActionCreator = (wallets, email, meta) => ({
   type: NotificationAction.SubscribeWalletAction,
   payload: { wallets, email },
+  meta,
 });
 
 export const subscribeWalletSuccess = (sessionToken: string): SubscribeWalletSuccessAction => ({
@@ -245,10 +252,15 @@ export const subscribeWalletFailure = (error: string): SubscribeWalletFailureAct
   error,
 });
 
-export type UnsubscribeWalletActionCreator = (wallets: Wallet[], email: string) => UnsubscribeWalletAction;
-export const unsubscribeWallet: UnsubscribeWalletActionCreator = (wallets, email) => ({
+export type UnsubscribeWalletActionCreator = (
+  wallets: Wallet[],
+  email: string,
+  meta?: ActionMeta,
+) => UnsubscribeWalletAction;
+export const unsubscribeWallet: UnsubscribeWalletActionCreator = (wallets, email, meta) => ({
   type: NotificationAction.UnsubscribeWalletAction,
   payload: { wallets, email },
+  meta,
 });
 
 export const unsubscribeWalletSuccess = (sessionToken: string): SubscribeWalletSuccessAction => ({

--- a/src/state/notifications/reducer.ts
+++ b/src/state/notifications/reducer.ts
@@ -39,8 +39,10 @@ const reducer = (state = initialState, action: NotificationActionType): Notifica
       };
     case NotificationAction.UnsubscribeWalletAction:
     case NotificationAction.SubscribeWalletAction:
+    case NotificationAction.UpdateNotificationEmailAction:
       return {
         ...state,
+        isLoading: true,
         failedTries: 0,
       };
     case NotificationAction.SubscribeWalletFailureAction:
@@ -85,6 +87,7 @@ const reducer = (state = initialState, action: NotificationActionType): Notifica
     case NotificationAction.UpdateNotificationEmailSuccessAction:
       return {
         ...state,
+        isLoading: false,
         sessionToken: action.payload.sessionToken,
       };
     case NotificationAction.AuthenticateEmailSuccessAction:

--- a/src/state/notifications/sagas.ts
+++ b/src/state/notifications/sagas.ts
@@ -82,27 +82,37 @@ export function* verifyNotificationEmailSaga(action: VerifyNotificationEmailActi
 export function* subscribeWalletSaga(action: SubscribeWalletAction) {
   const {
     payload: { wallets, email },
+    meta,
   } = action as SubscribeWalletAction;
 
   try {
     const walletsGenerationBase = yield all(wallets.map(wallet => call(walletToAddressesGenerationBase, wallet)));
 
     const lang = yield select(appSettingsSelectors.language);
-    const { session_token, result } = yield call(subscribeEmail, {
+    const { session_token } = yield call(subscribeEmail, {
       email,
       wallets: walletsGenerationBase,
       lang,
     });
 
     yield put(subscribeWalletSuccess(session_token));
+
+    if (meta?.onSuccess) {
+      meta.onSuccess();
+    }
   } catch (error) {
     yield put(subscribeWalletFailure(error.message));
+
+    if (meta?.onFailure) {
+      meta.onFailure();
+    }
   }
 }
 
 export function* unsubscribeWalletSaga(action: UnsubscribeWalletAction) {
   const {
     payload: { wallets, email },
+    meta,
   } = action as UnsubscribeWalletAction;
 
   try {
@@ -111,8 +121,16 @@ export function* unsubscribeWalletSaga(action: UnsubscribeWalletAction) {
     const { session_token } = yield call(unsubscribeEmail, { hashes, email });
 
     yield put(unsubscribeWalletSuccess(session_token));
+
+    if (meta?.onSuccess) {
+      meta.onSuccess();
+    }
   } catch (error) {
     yield put(unsubscribeWalletFailure(error.message));
+
+    if (meta?.onFailure) {
+      meta.onFailure();
+    }
   }
 }
 


### PR DESCRIPTION
## What does this PR do?

Call basic request (subscribe/unsubscribe/modify) before going to confirm screen so that allows handling error from basic requests on dedicated screens. Fixed loader buttons. Fixed deleting email with the unsubscribing flow.

## Todos:

- [x] Checked on iOS
- [x] Checked on Android

