### PR TITLE
transactions with notes on recovery screen

### DIFF
--- a/src/screens/Dashboard/DashboardScreen.tsx
+++ b/src/screens/Dashboard/DashboardScreen.tsx
@@ -213,7 +213,6 @@ class DashboardScreen extends Component<Props, State> {
 
   getTransactions = () => {
     const { allTransactions } = this.props;
-
     const activeWallet = this.getActiveWallet();
 
     return isAllWallets(activeWallet) ? allTransactions : allTransactions.filter(t => t.walletId === activeWallet.id);

--- a/src/screens/ImportWalletScreen.tsx
+++ b/src/screens/ImportWalletScreen.tsx
@@ -1,6 +1,6 @@
 import { RouteProp } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
-import { compose, debounce } from 'lodash/fp';
+import { compose } from 'lodash/fp';
 import React, { Component } from 'react';
 import { View, StyleSheet, Text, Keyboard, Alert } from 'react-native';
 import { connect } from 'react-redux';
@@ -127,7 +127,7 @@ export class ImportWalletScreen extends Component<Props, State> {
   };
 
   onChangeText = (mnemonic: string) => {
-    debounce(200)(() => this.setState({ text: mnemonic }));
+    this.setState({ text: mnemonic });
   };
 
   onLabelChange = (value: string) => {

--- a/src/screens/RecoveryTransactionList/RecoveryTransactionListScreen.tsx
+++ b/src/screens/RecoveryTransactionList/RecoveryTransactionListScreen.tsx
@@ -63,11 +63,11 @@ export class RecoveryTransactionListScreen extends PureComponent<Props, State> {
     );
   };
 
-  addTranscation = (transaction: Transaction) => {
+  addTransaction = (transaction: Transaction) => {
     this.setState((state: State) => ({ selectedTransactions: [...state.selectedTransactions, transaction] }));
   };
 
-  removeTranscation = (transaction: Transaction) => {
+  removeTransaction = (transaction: Transaction) => {
     this.setState((state: State) => ({
       selectedTransactions: state.selectedTransactions.filter(t => t.hash !== transaction.hash),
     }));
@@ -115,7 +115,7 @@ export class RecoveryTransactionListScreen extends PureComponent<Props, State> {
   };
 
   toggleTransaction = (isChecked: boolean, transaction: Transaction) => () =>
-    isChecked ? this.removeTranscation(transaction) : this.addTranscation(transaction);
+    isChecked ? this.removeTransaction(transaction) : this.addTransaction(transaction);
 
   renderItem = ({ item: transaction }: { item: Transaction }) => {
     const isChecked = this.isChecked(transaction);
@@ -126,7 +126,7 @@ export class RecoveryTransactionListScreen extends PureComponent<Props, State> {
         <View style={styles.transactionItemContainer}>
           <TransactionItem onPress={toggle} item={transaction} />
         </View>
-        <CheckBox onPress={toggle} right checked={isChecked} />
+        <CheckBox testID={`transaction-${transaction.note}-checkbox`} onPress={toggle} right checked={isChecked} />
       </View>
     );
   };

--- a/src/screens/SendCoinsScreen.tsx
+++ b/src/screens/SendCoinsScreen.tsx
@@ -493,7 +493,7 @@ class SendCoinsScreen extends Component<Props, State> {
     return wallet.type === HDSegwitP2SHAirWallet.type;
   };
 
-  onVaultTranscationSelect = (vaultTxType: number) => {
+  onVaultTransactionSelect = (vaultTxType: number) => {
     this.setState({ vaultTxType });
   };
 
@@ -508,7 +508,7 @@ class SendCoinsScreen extends Component<Props, State> {
           subtitle={i18n.send.transaction.alertDesc}
           value={bitcoin.payments.VaultTxType.Alert}
           checked={this.state.vaultTxType === bitcoin.payments.VaultTxType.Alert}
-          onPress={this.onVaultTranscationSelect}
+          onPress={this.onVaultTransactionSelect}
         />
         <RadioButton
           testID="send-coins-secure-fast-transaction-type-radio"
@@ -516,7 +516,7 @@ class SendCoinsScreen extends Component<Props, State> {
           subtitle={i18n.send.transaction.instantDesc}
           value={bitcoin.payments.VaultTxType.Instant}
           checked={this.state.vaultTxType === bitcoin.payments.VaultTxType.Instant}
-          onPress={this.onVaultTranscationSelect}
+          onPress={this.onVaultTransactionSelect}
         />
       </View>
     );

--- a/src/state/wallets/selectors.ts
+++ b/src/state/wallets/selectors.ts
@@ -15,6 +15,7 @@ import {
 } from 'app/consts';
 import { HDSegwitP2SHArWallet, HDSegwitP2SHAirWallet } from 'app/legacy';
 import { ApplicationState } from 'app/state';
+import { transactionNotes } from 'app/state/transactionsNotes/selectors';
 
 import logger from '../../../logger';
 import { roundBtcToSatoshis, btcToSatoshi, satoshiToBtc } from '../../../utils/bitcoin';
@@ -118,7 +119,7 @@ const getMyAmount = (wallet: Wallet, entities: TxEntity[]) =>
     return amount;
   }, 0);
 
-const getTranasctionStatus = (tx: Transaction, confirmations: number): TransactionStatus => {
+const getTransactionStatus = (tx: Transaction, confirmations: number): TransactionStatus => {
   switch (tx.tx_type) {
     case TxType.NONVAULT:
     case TxType.INSTANT:
@@ -208,7 +209,7 @@ export const transactions = createSelector(wallets, electrumXSelectors.blockHeig
           confirmations,
           walletPreferredBalanceUnit: walletBalanceUnit,
           walletId: id,
-          status: getTranasctionStatus(transaction, confirmations),
+          status: getTransactionStatus(transaction, confirmations),
           walletLabel,
           walletTypeReadable: wallet.typeReadable,
         };
@@ -310,17 +311,21 @@ export const transactions = createSelector(wallets, electrumXSelectors.blockHeig
     .map(tx => ({ ...tx, tags: getTranasctionTags(tx) }));
 });
 
-export const getTranasctionsByWalletId = createSelector(
-  transactions,
+export const transactionsWithNotes = createSelector(transactions, transactionNotes, (transactions, notes) =>
+  transactions.map(tran => (notes[tran.hash] ? { ...tran, note: notes[tran.hash] } : tran)),
+);
+
+export const getTransactionsByWalletId = createSelector(
+  transactionsWithNotes,
   (_: WalletsState, id: string) => id,
   (txs, id) => txs.filter(t => t.walletId === id),
 );
 
-export const getRecoveryTransactions = createSelector(getTranasctionsByWalletId, txs =>
+export const getRecoveryTransactionsWithNotes = createSelector(getTransactionsByWalletId, txs =>
   txs.filter(t => t.tx_type === TxType.RECOVERY),
 );
 
-export const getAlertPendingTransactions = createSelector(getTranasctionsByWalletId, txs =>
+export const getAlertPendingTransactions = createSelector(getTransactionsByWalletId, txs =>
   txs.filter(t => t.tx_type === TxType.ALERT_PENDING),
 );
 


### PR DESCRIPTION
## What does this PR do?

Shows transaction notes also on recovery screen to e2e tests

## Todos:

- [ ] Checked on iOS
- [x] Checked on Android

