### PR TITLE
Bugfix able to save an address contact without name

### DIFF
--- a/loc/en.js
+++ b/loc/en.js
@@ -134,6 +134,7 @@ module.exports = {
     buttonLabel: 'Add new contact',
     description: 'Please enter name and address\n for your new contact.',
     nameCannotContainSpecialCharactersError: 'Name cannot contain special characters.',
+    nameCannotEmpty: 'Name cannot be empty field',
     nameLabel: 'Name',
     nameMissingAlphanumericCharacterError: 'Name is missing alphanumeric character.',
     screenTitle: 'Add new contact',

--- a/src/components/GenericInputItem.tsx
+++ b/src/components/GenericInputItem.tsx
@@ -10,6 +10,7 @@ interface Props {
   title: string;
   value?: string;
   validate?: (value: string) => string | undefined;
+  validateName?: boolean;
   validateOnSave?: (value: string) => void;
   onSave?: (value: string) => void;
   maxLength?: number;
@@ -25,13 +26,14 @@ export const GenericInputItem = (props: Props) => {
     value && props.onSave && props.onSave(newValue);
   };
   const onFocus = () => {
-    const { maxLength, validate, validateOnSave } = props;
+    const { maxLength, validate, validateOnSave, validateName } = props;
 
     NavigationService.navigate(Route.EditText, {
       title,
       label,
       value,
       validate,
+      validateName,
       validateOnSave,
       onSave: handleValueSave,
       maxLength,

--- a/src/components/GenericInputItem.tsx
+++ b/src/components/GenericInputItem.tsx
@@ -21,7 +21,7 @@ export const GenericInputItem = (props: Props) => {
   const [title] = useState(props.title);
   const [value, setValue] = useState(props.value);
   const handleValueSave = (newValue: string) => {
-    setValue(newValue);
+    setValue(newValue.trim());
     value && props.onSave && props.onSave(newValue);
   };
   const onFocus = () => {

--- a/src/consts/models.tsx
+++ b/src/consts/models.tsx
@@ -395,6 +395,7 @@ export type RootStackParams = {
     value?: string;
     inputTestID?: string;
     submitButtonTestID?: string;
+    validateName?: boolean;
     validate?: (value: string) => string | undefined;
     validateOnSave?: (value: string) => void;
     keyboardType?: KeyboardType;

--- a/src/screens/ContactDetailsScreen.tsx
+++ b/src/screens/ContactDetailsScreen.tsx
@@ -61,6 +61,12 @@ export class ContactDetailsScreen extends React.PureComponent<Props, State> {
     checkAddress(address);
   };
 
+  validateName = (value: string) => {
+    if (value.match(/[@'|"“”‘|’„”,.;]/g)?.length) {
+      throw Error('no special characters');
+    }
+  };
+
   saveChanges = (changes: Partial<Contact>) => {
     const { contact } = this.props.route.params;
 
@@ -128,6 +134,8 @@ export class ContactDetailsScreen extends React.PureComponent<Props, State> {
             title={i18n.contactDetails.editName}
             label={i18n.contactDetails.nameLabel}
             value={name}
+            validateName
+            validateOnSave={this.validateName}
             onSave={this.setName}
           />
         </View>

--- a/src/screens/ContactDetailsScreen.tsx
+++ b/src/screens/ContactDetailsScreen.tsx
@@ -46,8 +46,10 @@ export class ContactDetailsScreen extends React.PureComponent<Props, State> {
   }
 
   setName = (name: string) => {
-    this.setState({ name });
-    this.saveChanges({ name });
+    const trimmedName = name.trim();
+
+    this.setState({ name: trimmedName });
+    this.saveChanges({ name: trimmedName });
   };
 
   setAddress = (address: string) => {
@@ -61,6 +63,7 @@ export class ContactDetailsScreen extends React.PureComponent<Props, State> {
 
   saveChanges = (changes: Partial<Contact>) => {
     const { contact } = this.props.route.params;
+
     const updatedContact = { ...contact, ...changes };
 
     this.props.navigation.setParams({ contact: updatedContact });

--- a/src/screens/CreateContactScreen.tsx
+++ b/src/screens/CreateContactScreen.tsx
@@ -112,6 +112,9 @@ export class CreateContactScreen extends React.PureComponent<Props, State> {
     if (value.match(/[@'|"“”‘|’„”,.;]/g)?.length) {
       return i18n.contactCreate.nameCannotContainSpecialCharactersError;
     }
+    if (!!!value.length) {
+      return i18n.contactCreate.nameCannotEmpty;
+    }
     return '';
   };
 

--- a/src/screens/EditTextScreen.tsx
+++ b/src/screens/EditTextScreen.tsx
@@ -1,6 +1,6 @@
 import { RouteProp } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { View, StyleSheet } from 'react-native';
 
 import { Header, InputItem, Button, ScreenTemplate } from 'app/components';
@@ -25,6 +25,7 @@ export const EditTextScreen = (props: Props) => {
     checkZero,
     keyboardType = defaultKeyboardType,
     validate,
+    validateName,
     validateOnSave = null,
     emptyValueAllowed = false,
     value: paramsValue,
@@ -33,12 +34,21 @@ export const EditTextScreen = (props: Props) => {
   const [value, setValue] = useState(paramsValue || '');
   const [error, setError] = useState('');
 
+  useEffect(() => {
+    setError('');
+  }, [value]);
+
   const handlePressOnSaveButton = () => {
     if (validateOnSave) {
       try {
         validateOnSave(value);
       } catch (err) {
-        setError(i18n.send.details.address_field_is_not_valid);
+        if (validateName) {
+          setError(i18n.contactCreate.nameCannotContainSpecialCharactersError);
+        } else {
+          setError(i18n.send.details.address_field_is_not_valid);
+        }
+
         return;
       }
     }
@@ -47,7 +57,7 @@ export const EditTextScreen = (props: Props) => {
   };
 
   const canSubmit = () => {
-    if (!value) {
+    if (!value.trim()) {
       return emptyValueAllowed;
     }
 


### PR DESCRIPTION
## What does this PR do?
Fix for
1. After adding a contact with only spaces in the name field and changing it later, the name is not saving
2. If we save a contact with space in from of the name, we don't have a prefix letter, contact is not in the right order (if we add a new contact with space " abc" for example, space is removing and everything is fine, but it's work differently while editing a contact)

#### *Where should the reviewer start?*

#### *Any background context you want to provide?*

#### *Any scout cleaning/refactoring?*

#### *Any blog post related to the solution you have used?*

## Todos:

- [x] Checked on iOS
- [ ] Checked on Android

## Required reviewers:
