### PR TITLE
Fixed background lock

### DIFF
--- a/src/services/AppStateManager.tsx
+++ b/src/services/AppStateManager.tsx
@@ -15,8 +15,6 @@ export default class AppStateManager extends PureComponent<Props, State> {
     appState: AppState.currentState,
   };
 
-  backgroundTimer: any;
-
   componentDidMount() {
     AppState.addEventListener('change', this.handleAppStateChange);
   }
@@ -29,19 +27,13 @@ export default class AppStateManager extends PureComponent<Props, State> {
     const { handleAppComesToForeground, handleAppComesToBackground } = this.props;
     const { appState } = this.state;
 
-    if (this.backgroundTimer) {
-      clearTimeout(this.backgroundTimer);
-    }
-
     // TODO: inactive state always invoked by biometric scan, so we can't use inactive state to show lock screen, so only background state valid option. It may be changed or fixed later
     if (appState === 'background' && nextAppState === 'active') {
       !!handleAppComesToForeground && handleAppComesToForeground();
     }
 
     if (nextAppState === 'background') {
-      this.backgroundTimer = setTimeout(() => {
-        !!handleAppComesToBackground && handleAppComesToBackground();
-      }, 15000); // Show lock screen after 15 sec inactive app
+      !!handleAppComesToBackground && handleAppComesToBackground();
     }
 
     this.setState({ appState: nextAppState });

--- a/src/services/AppStateManager.tsx
+++ b/src/services/AppStateManager.tsx
@@ -15,6 +15,8 @@ export default class AppStateManager extends PureComponent<Props, State> {
     appState: AppState.currentState,
   };
 
+  backgroundTimer: any;
+
   componentDidMount() {
     AppState.addEventListener('change', this.handleAppStateChange);
   }
@@ -24,15 +26,22 @@ export default class AppStateManager extends PureComponent<Props, State> {
   }
 
   handleAppStateChange = (nextAppState: string) => {
-    const { handleAppComesToBackground, handleAppComesToForeground } = this.props;
+    const { handleAppComesToForeground, handleAppComesToBackground } = this.props;
     const { appState } = this.state;
 
-    if ((appState === 'background' || appState === 'inactive') && nextAppState === 'active') {
+    if (this.backgroundTimer) {
+      clearTimeout(this.backgroundTimer);
+    }
+
+    // TODO: inactive state always invoked by biometric scan, so we can't use inactive state to show lock screen, so only background state valid option. It may be changed or fixed later
+    if (appState === 'background' && nextAppState === 'active') {
       !!handleAppComesToForeground && handleAppComesToForeground();
     }
 
-    if (nextAppState !== 'active') {
-      !!handleAppComesToBackground && handleAppComesToBackground();
+    if (nextAppState === 'background') {
+      this.backgroundTimer = setTimeout(() => {
+        !!handleAppComesToBackground && handleAppComesToBackground();
+      }, 15000); // Show lock screen after 15 sec inactive app
     }
 
     this.setState({ appState: nextAppState });


### PR DESCRIPTION
## What does this PR do?

Fixed biometric Cancel event lead to launch biometric again and again.

Prevent show lock screen immediately after app go to background - set to show lock screen after 15 sec being in background

- [+] Checked on iOS
- [+] Checked on Android

## Required reviewers:
